### PR TITLE
docs: adding backoff to quickstart test

### DIFF
--- a/samples/snippets/quickstart/quickstart_test.py
+++ b/samples/snippets/quickstart/quickstart_test.py
@@ -15,6 +15,8 @@
 import os
 import uuid
 
+import backoff
+from google.api_core.exceptions import ServiceUnavailable
 from google.cloud import dataproc_v1 as dataproc
 from google.cloud import storage
 import pytest
@@ -39,7 +41,14 @@ SORT_CODE = (
 @pytest.fixture(autouse=True)
 def setup_teardown():
     storage_client = storage.Client()
-    bucket = storage_client.create_bucket(STAGING_BUCKET)
+
+    @backoff.on_exception(backoff.expo,
+                          ServiceUnavailable,
+                          max_tries=5)
+    def create_bucket(): 
+        return storage_client.create_bucket(STAGING_BUCKET)
+    
+    bucket = create_bucket()
     blob = bucket.blob(JOB_FILE_NAME)
     blob.upload_from_string(SORT_CODE)
 

--- a/samples/snippets/quickstart/quickstart_test.py
+++ b/samples/snippets/quickstart/quickstart_test.py
@@ -45,9 +45,9 @@ def setup_teardown():
     @backoff.on_exception(backoff.expo,
                           ServiceUnavailable,
                           max_tries=5)
-    def create_bucket(): 
+    def create_bucket():
         return storage_client.create_bucket(STAGING_BUCKET)
-    
+
     bucket = create_bucket()
     blob = bucket.blob(JOB_FILE_NAME)
     blob.upload_from_string(SORT_CODE)

--- a/samples/snippets/requirements.txt
+++ b/samples/snippets/requirements.txt
@@ -1,3 +1,4 @@
+backoff==1.10.0
 grpcio==1.35.0
 google-auth==1.27.0
 google-auth-httplib2==0.0.4


### PR DESCRIPTION
Fixes https://github.com/googleapis/python-dataproc/issues/133 by adding exponential backoff
