### PR TITLE
fix: (samples) fixing samples for new machine types

### DIFF
--- a/samples/snippets/create_cluster.py
+++ b/samples/snippets/create_cluster.py
@@ -47,8 +47,8 @@ def create_cluster(project_id, region, cluster_name):
         "project_id": project_id,
         "cluster_name": cluster_name,
         "config": {
-            "master_config": {"num_instances": 1, "machine_type_uri": "n1-standard-1"},
-            "worker_config": {"num_instances": 2, "machine_type_uri": "n1-standard-1"},
+            "master_config": {"num_instances": 1, "machine_type_uri": "n1-standard-2"},
+            "worker_config": {"num_instances": 2, "machine_type_uri": "n1-standard-2"},
         },
     }
 

--- a/samples/snippets/quickstart/quickstart.py
+++ b/samples/snippets/quickstart/quickstart.py
@@ -44,8 +44,8 @@ def quickstart(project_id, region, cluster_name, job_file_path):
         "project_id": project_id,
         "cluster_name": cluster_name,
         "config": {
-            "master_config": {"num_instances": 1, "machine_type_uri": "n1-standard-1"},
-            "worker_config": {"num_instances": 2, "machine_type_uri": "n1-standard-1"},
+            "master_config": {"num_instances": 1, "machine_type_uri": "n1-standard-2"},
+            "worker_config": {"num_instances": 2, "machine_type_uri": "n1-standard-2"},
         },
     }
 

--- a/samples/snippets/submit_job_test.py
+++ b/samples/snippets/submit_job_test.py
@@ -30,11 +30,11 @@ CLUSTER = {
     'config': {
         'master_config': {
             'num_instances': 1,
-            'machine_type_uri': 'n1-standard-1'
+            'machine_type_uri': 'n1-standard-2'
         },
         'worker_config': {
             'num_instances': 2,
-            'machine_type_uri': 'n1-standard-1'
+            'machine_type_uri': 'n1-standard-2'
         }
     }
 }


### PR DESCRIPTION
Dataproc 2.0 is the new default image which does not support n1-standard-1.

Fixes https://github.com/googleapis/python-dataproc/issues/147, https://github.com/googleapis/python-dataproc/issues/148, https://github.com/googleapis/python-dataproc/issues/149
