### PR TITLE
Fix attribute error `Name` while getting the status of cluster

### DIFF
--- a/samples/snippets/submit_job_to_cluster.py
+++ b/samples/snippets/submit_job_to_cluster.py
@@ -137,7 +137,7 @@ def list_clusters_with_details(dataproc, project, region):
             (
                 "{} - {}".format(
                     cluster.cluster_name,
-                    cluster.status.State.Name(cluster.status.state),
+                    cluster.status.state.name,
                 )
             )
         )


### PR DESCRIPTION
`cluster.status.State.Name(cluster.status.state),`  this code will throw an attribute error when executed because it's trying to access State.Name which is not a function of class ClusterStatus.State
A better approach will be to use the `cluster.status.state.name` as State is of enum type

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-dataproc/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #170   🦕
