### PR TITLE
chore: add codeowner_team to repo-metadata.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-# The @googleapis/yoshi-python is the default owner for changes in this repo
-*               @googleapis/api-dataproc @googleapis/yoshi-python 
+# @googleapis/yoshi-python and @googleapis/api-dataproc are the default owners for changes in this repo
+*     @googleapis/yoshi-python @googleapis/api-dataproc
 
-# The python-samples-reviewers team is the default owner for samples changes
-/samples/**/*.py   @loferris @googleapis/api-dataproc @googleapis/python-samples-owners 
+# @googleapis/python-samples-owners and @googleapis/api-dataproc are the default owners for samples changes
+/samples/   @googleapis/python-samples-owners @googleapis/api-dataproc

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,5 +10,6 @@
   "repo": "googleapis/python-dataproc",
   "distribution_name": "google-cloud-dataproc",
   "api_id": "dataproc.googleapis.com",
-  "requires_billing": true
+  "requires_billing": true,
+  "codeowner_team": "@googleapis/api-dataproc"
 }


### PR DESCRIPTION
Required for https://github.com/googleapis/synthtool/pull/1201. For changes to the `CODEOWNERS` file, please submit a code review for https://github.com/googleapis/synthtool/pull/1201.