### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Python Client for Google Cloud Dataproc API
 - `Product Documentation`_
 
 .. |ga| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#ga-support
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#ga-support
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-dataproc.svg
    :target: https://pypi.org/project/google-cloud-dataproc/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dataproc.svg


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.