### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "dataproc",
     "name_pretty": "Google Cloud Dataproc",
     "product_documentation": "https://cloud.google.com/dataproc",
-    "client_documentation": "https://googleapis.dev/python/dataproc/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/dataproc/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559745",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Google Cloud Dataproc API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dataproc.svg
    :target: https://pypi.org/project/google-cloud-dataproc/
 .. _Google Cloud Dataproc API: https://cloud.google.com/dataproc
-.. _Client Library Documentation: https://googleapis.dev/python/dataproc/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dataproc/latest
 .. _Product Documentation:  https://cloud.google.com/dataproc
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.