### PR TITLE
chore(samples): fix job polling

### DIFF
--- a/samples/snippets/submit_job_to_cluster.py
+++ b/samples/snippets/submit_job_to_cluster.py
@@ -202,9 +202,9 @@ def wait_for_job(dataproc, project, region, job_id):
             request={"project_id": project, "region": region, "job_id": job_id}
         )
         # Handle exceptions
-        if job.status.State.Name(job.status.state) == "ERROR":
+        if job.status.State(job.status.state).name == "ERROR":
             raise Exception(job.status.details)
-        elif job.status.State.Name(job.status.state) == "DONE":
+        elif job.status.State(job.status.state).name == "DONE":
             print("Job finished.")
             return job
 

--- a/samples/snippets/submit_job_to_cluster.py
+++ b/samples/snippets/submit_job_to_cluster.py
@@ -204,7 +204,7 @@ def wait_for_job(dataproc, project, region, job_id):
         # Handle exceptions
         if job.status.State(job.status.state).name == "ERROR":
             raise Exception(job.status.details)
-        elif job.status.State(job.status.state).name == "DONE":
+        if job.status.State(job.status.state).name == "DONE":
             print("Job finished.")
             return job
 


### PR DESCRIPTION
Fixes failure:

```
Waiting for job to finish...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 9, in wait_for_job
  File "/opt/conda/default/lib/python3.8/enum.py", line 384, in __getattr__
    raise AttributeError(name) from None
AttributeError: Name
```