### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v3 release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -361,7 +361,10 @@ texinfo_documents = [
 intersphinx_mapping = {
     "python": ("https://python.readthedocs.org/en/latest/", None),
     "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None,),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
     "grpc": ("https://grpc.github.io/grpc/python/", None),
     "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),

--- a/google/cloud/dataproc_v1/services/autoscaling_policy_service/async_client.py
+++ b/google/cloud/dataproc_v1/services/autoscaling_policy_service/async_client.py
@@ -327,7 +327,12 @@ class AutoscalingPolicyServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -440,7 +445,12 @@ class AutoscalingPolicyServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -550,7 +560,12 @@ class AutoscalingPolicyServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -666,12 +681,20 @@ class AutoscalingPolicyServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListAutoscalingPoliciesAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -773,7 +796,10 @@ class AutoscalingPolicyServiceAsyncClient:
 
         # Send the request.
         await rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     async def __aenter__(self):
@@ -785,7 +811,9 @@ class AutoscalingPolicyServiceAsyncClient:
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/autoscaling_policy_service/client.py
+++ b/google/cloud/dataproc_v1/services/autoscaling_policy_service/client.py
@@ -56,7 +56,8 @@ class AutoscalingPolicyServiceClientMeta(type):
     _transport_registry["grpc_asyncio"] = AutoscalingPolicyServiceGrpcAsyncIOTransport
 
     def get_transport_class(
-        cls, label: str = None,
+        cls,
+        label: str = None,
     ) -> Type[AutoscalingPolicyServiceTransport]:
         """Returns an appropriate transport class.
 
@@ -165,11 +166,15 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
 
     @staticmethod
     def autoscaling_policy_path(
-        project: str, location: str, autoscaling_policy: str,
+        project: str,
+        location: str,
+        autoscaling_policy: str,
     ) -> str:
         """Returns a fully-qualified autoscaling_policy string."""
         return "projects/{project}/locations/{location}/autoscalingPolicies/{autoscaling_policy}".format(
-            project=project, location=location, autoscaling_policy=autoscaling_policy,
+            project=project,
+            location=location,
+            autoscaling_policy=autoscaling_policy,
         )
 
     @staticmethod
@@ -182,7 +187,9 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_billing_account_path(billing_account: str,) -> str:
+    def common_billing_account_path(
+        billing_account: str,
+    ) -> str:
         """Returns a fully-qualified billing_account string."""
         return "billingAccounts/{billing_account}".format(
             billing_account=billing_account,
@@ -195,9 +202,13 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_folder_path(folder: str,) -> str:
+    def common_folder_path(
+        folder: str,
+    ) -> str:
         """Returns a fully-qualified folder string."""
-        return "folders/{folder}".format(folder=folder,)
+        return "folders/{folder}".format(
+            folder=folder,
+        )
 
     @staticmethod
     def parse_common_folder_path(path: str) -> Dict[str, str]:
@@ -206,9 +217,13 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_organization_path(organization: str,) -> str:
+    def common_organization_path(
+        organization: str,
+    ) -> str:
         """Returns a fully-qualified organization string."""
-        return "organizations/{organization}".format(organization=organization,)
+        return "organizations/{organization}".format(
+            organization=organization,
+        )
 
     @staticmethod
     def parse_common_organization_path(path: str) -> Dict[str, str]:
@@ -217,9 +232,13 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_project_path(project: str,) -> str:
+    def common_project_path(
+        project: str,
+    ) -> str:
         """Returns a fully-qualified project string."""
-        return "projects/{project}".format(project=project,)
+        return "projects/{project}".format(
+            project=project,
+        )
 
     @staticmethod
     def parse_common_project_path(path: str) -> Dict[str, str]:
@@ -228,10 +247,14 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_location_path(project: str, location: str,) -> str:
+    def common_location_path(
+        project: str,
+        location: str,
+    ) -> str:
         """Returns a fully-qualified location string."""
         return "projects/{project}/locations/{location}".format(
-            project=project, location=location,
+            project=project,
+            location=location,
         )
 
     @staticmethod
@@ -522,7 +545,12 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -628,7 +656,12 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -729,7 +762,12 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -838,12 +876,20 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListAutoscalingPoliciesPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -948,7 +994,10 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
 
         # Send the request.
         rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     def __enter__(self):
@@ -967,7 +1016,9 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/base.py
+++ b/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/base.py
@@ -30,7 +30,9 @@ from google.protobuf import empty_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
@@ -179,9 +181,9 @@ class AutoscalingPolicyServiceTransport(abc.ABC):
     def close(self):
         """Closes resources associated with the transport.
 
-       .. warning::
-            Only call this method if the transport is NOT shared
-            with other clients - this may cause errors in other clients!
+        .. warning::
+             Only call this method if the transport is NOT shared
+             with other clients - this may cause errors in other clients!
         """
         raise NotImplementedError()
 

--- a/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc.py
+++ b/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc.py
@@ -226,8 +226,7 @@ class AutoscalingPolicyServiceGrpcTransport(AutoscalingPolicyServiceTransport):
 
     @property
     def grpc_channel(self) -> grpc.Channel:
-        """Return the channel designed to connect to this service.
-        """
+        """Return the channel designed to connect to this service."""
         return self._grpc_channel
 
     @property

--- a/google/cloud/dataproc_v1/services/batch_controller/async_client.py
+++ b/google/cloud/dataproc_v1/services/batch_controller/async_client.py
@@ -328,7 +328,12 @@ class BatchControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -426,7 +431,12 @@ class BatchControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -519,12 +529,20 @@ class BatchControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListBatchesAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -610,7 +628,10 @@ class BatchControllerAsyncClient:
 
         # Send the request.
         await rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     async def __aenter__(self):
@@ -622,7 +643,9 @@ class BatchControllerAsyncClient:
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/batch_controller/client.py
+++ b/google/cloud/dataproc_v1/services/batch_controller/client.py
@@ -60,7 +60,10 @@ class BatchControllerClientMeta(type):
     _transport_registry["grpc"] = BatchControllerGrpcTransport
     _transport_registry["grpc_asyncio"] = BatchControllerGrpcAsyncIOTransport
 
-    def get_transport_class(cls, label: str = None,) -> Type[BatchControllerTransport]:
+    def get_transport_class(
+        cls,
+        label: str = None,
+    ) -> Type[BatchControllerTransport]:
         """Returns an appropriate transport class.
 
         Args:
@@ -167,10 +170,16 @@ class BatchControllerClient(metaclass=BatchControllerClientMeta):
         return self._transport
 
     @staticmethod
-    def batch_path(project: str, location: str, batch: str,) -> str:
+    def batch_path(
+        project: str,
+        location: str,
+        batch: str,
+    ) -> str:
         """Returns a fully-qualified batch string."""
         return "projects/{project}/locations/{location}/batches/{batch}".format(
-            project=project, location=location, batch=batch,
+            project=project,
+            location=location,
+            batch=batch,
         )
 
     @staticmethod
@@ -183,7 +192,9 @@ class BatchControllerClient(metaclass=BatchControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_billing_account_path(billing_account: str,) -> str:
+    def common_billing_account_path(
+        billing_account: str,
+    ) -> str:
         """Returns a fully-qualified billing_account string."""
         return "billingAccounts/{billing_account}".format(
             billing_account=billing_account,
@@ -196,9 +207,13 @@ class BatchControllerClient(metaclass=BatchControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_folder_path(folder: str,) -> str:
+    def common_folder_path(
+        folder: str,
+    ) -> str:
         """Returns a fully-qualified folder string."""
-        return "folders/{folder}".format(folder=folder,)
+        return "folders/{folder}".format(
+            folder=folder,
+        )
 
     @staticmethod
     def parse_common_folder_path(path: str) -> Dict[str, str]:
@@ -207,9 +222,13 @@ class BatchControllerClient(metaclass=BatchControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_organization_path(organization: str,) -> str:
+    def common_organization_path(
+        organization: str,
+    ) -> str:
         """Returns a fully-qualified organization string."""
-        return "organizations/{organization}".format(organization=organization,)
+        return "organizations/{organization}".format(
+            organization=organization,
+        )
 
     @staticmethod
     def parse_common_organization_path(path: str) -> Dict[str, str]:
@@ -218,9 +237,13 @@ class BatchControllerClient(metaclass=BatchControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_project_path(project: str,) -> str:
+    def common_project_path(
+        project: str,
+    ) -> str:
         """Returns a fully-qualified project string."""
-        return "projects/{project}".format(project=project,)
+        return "projects/{project}".format(
+            project=project,
+        )
 
     @staticmethod
     def parse_common_project_path(path: str) -> Dict[str, str]:
@@ -229,10 +252,14 @@ class BatchControllerClient(metaclass=BatchControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_location_path(project: str, location: str,) -> str:
+    def common_location_path(
+        project: str,
+        location: str,
+    ) -> str:
         """Returns a fully-qualified location string."""
         return "projects/{project}/locations/{location}".format(
-            project=project, location=location,
+            project=project,
+            location=location,
         )
 
     @staticmethod
@@ -526,7 +553,12 @@ class BatchControllerClient(metaclass=BatchControllerClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -625,7 +657,12 @@ class BatchControllerClient(metaclass=BatchControllerClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -719,12 +756,20 @@ class BatchControllerClient(metaclass=BatchControllerClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListBatchesPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -811,7 +856,10 @@ class BatchControllerClient(metaclass=BatchControllerClientMeta):
 
         # Send the request.
         rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     def __enter__(self):
@@ -830,7 +878,9 @@ class BatchControllerClient(metaclass=BatchControllerClientMeta):
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/batch_controller/transports/base.py
+++ b/google/cloud/dataproc_v1/services/batch_controller/transports/base.py
@@ -32,7 +32,9 @@ from google.protobuf import empty_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
@@ -122,25 +124,33 @@ class BatchControllerTransport(abc.ABC):
         # Precompute the wrapped methods.
         self._wrapped_methods = {
             self.create_batch: gapic_v1.method.wrap_method(
-                self.create_batch, default_timeout=None, client_info=client_info,
+                self.create_batch,
+                default_timeout=None,
+                client_info=client_info,
             ),
             self.get_batch: gapic_v1.method.wrap_method(
-                self.get_batch, default_timeout=None, client_info=client_info,
+                self.get_batch,
+                default_timeout=None,
+                client_info=client_info,
             ),
             self.list_batches: gapic_v1.method.wrap_method(
-                self.list_batches, default_timeout=None, client_info=client_info,
+                self.list_batches,
+                default_timeout=None,
+                client_info=client_info,
             ),
             self.delete_batch: gapic_v1.method.wrap_method(
-                self.delete_batch, default_timeout=None, client_info=client_info,
+                self.delete_batch,
+                default_timeout=None,
+                client_info=client_info,
             ),
         }
 
     def close(self):
         """Closes resources associated with the transport.
 
-       .. warning::
-            Only call this method if the transport is NOT shared
-            with other clients - this may cause errors in other clients!
+        .. warning::
+             Only call this method if the transport is NOT shared
+             with other clients - this may cause errors in other clients!
         """
         raise NotImplementedError()
 

--- a/google/cloud/dataproc_v1/services/batch_controller/transports/grpc.py
+++ b/google/cloud/dataproc_v1/services/batch_controller/transports/grpc.py
@@ -229,8 +229,7 @@ class BatchControllerGrpcTransport(BatchControllerTransport):
 
     @property
     def grpc_channel(self) -> grpc.Channel:
-        """Return the channel designed to connect to this service.
-        """
+        """Return the channel designed to connect to this service."""
         return self._grpc_channel
 
     @property

--- a/google/cloud/dataproc_v1/services/cluster_controller/async_client.py
+++ b/google/cloud/dataproc_v1/services/cluster_controller/async_client.py
@@ -333,7 +333,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -551,7 +556,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -628,7 +638,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -705,7 +720,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -847,7 +867,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -974,7 +999,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1118,12 +1148,20 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListClustersAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -1253,7 +1291,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -1275,7 +1318,9 @@ class ClusterControllerAsyncClient:
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/cluster_controller/client.py
+++ b/google/cloud/dataproc_v1/services/cluster_controller/client.py
@@ -61,7 +61,8 @@ class ClusterControllerClientMeta(type):
     _transport_registry["grpc_asyncio"] = ClusterControllerGrpcAsyncIOTransport
 
     def get_transport_class(
-        cls, label: str = None,
+        cls,
+        label: str = None,
     ) -> Type[ClusterControllerTransport]:
         """Returns an appropriate transport class.
 
@@ -169,10 +170,16 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return self._transport
 
     @staticmethod
-    def cluster_path(project: str, location: str, cluster: str,) -> str:
+    def cluster_path(
+        project: str,
+        location: str,
+        cluster: str,
+    ) -> str:
         """Returns a fully-qualified cluster string."""
         return "projects/{project}/locations/{location}/clusters/{cluster}".format(
-            project=project, location=location, cluster=cluster,
+            project=project,
+            location=location,
+            cluster=cluster,
         )
 
     @staticmethod
@@ -185,10 +192,16 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def service_path(project: str, location: str, service: str,) -> str:
+    def service_path(
+        project: str,
+        location: str,
+        service: str,
+    ) -> str:
         """Returns a fully-qualified service string."""
         return "projects/{project}/locations/{location}/services/{service}".format(
-            project=project, location=location, service=service,
+            project=project,
+            location=location,
+            service=service,
         )
 
     @staticmethod
@@ -201,7 +214,9 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_billing_account_path(billing_account: str,) -> str:
+    def common_billing_account_path(
+        billing_account: str,
+    ) -> str:
         """Returns a fully-qualified billing_account string."""
         return "billingAccounts/{billing_account}".format(
             billing_account=billing_account,
@@ -214,9 +229,13 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_folder_path(folder: str,) -> str:
+    def common_folder_path(
+        folder: str,
+    ) -> str:
         """Returns a fully-qualified folder string."""
-        return "folders/{folder}".format(folder=folder,)
+        return "folders/{folder}".format(
+            folder=folder,
+        )
 
     @staticmethod
     def parse_common_folder_path(path: str) -> Dict[str, str]:
@@ -225,9 +244,13 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_organization_path(organization: str,) -> str:
+    def common_organization_path(
+        organization: str,
+    ) -> str:
         """Returns a fully-qualified organization string."""
-        return "organizations/{organization}".format(organization=organization,)
+        return "organizations/{organization}".format(
+            organization=organization,
+        )
 
     @staticmethod
     def parse_common_organization_path(path: str) -> Dict[str, str]:
@@ -236,9 +259,13 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_project_path(project: str,) -> str:
+    def common_project_path(
+        project: str,
+    ) -> str:
         """Returns a fully-qualified project string."""
-        return "projects/{project}".format(project=project,)
+        return "projects/{project}".format(
+            project=project,
+        )
 
     @staticmethod
     def parse_common_project_path(path: str) -> Dict[str, str]:
@@ -247,10 +274,14 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_location_path(project: str, location: str,) -> str:
+    def common_location_path(
+        project: str,
+        location: str,
+    ) -> str:
         """Returns a fully-qualified location string."""
         return "projects/{project}/locations/{location}".format(
-            project=project, location=location,
+            project=project,
+            location=location,
         )
 
     @staticmethod
@@ -538,7 +569,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.create_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -748,7 +784,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.update_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -827,7 +868,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.stop_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -906,7 +952,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.start_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -1040,7 +1091,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.delete_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -1157,7 +1213,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.get_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1291,12 +1352,20 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.list_clusters]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListClustersPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -1418,7 +1487,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.diagnose_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -1447,7 +1521,9 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/cluster_controller/transports/base.py
+++ b/google/cloud/dataproc_v1/services/cluster_controller/transports/base.py
@@ -31,7 +31,9 @@ from google.longrunning import operations_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
@@ -149,10 +151,14 @@ class ClusterControllerTransport(abc.ABC):
                 client_info=client_info,
             ),
             self.stop_cluster: gapic_v1.method.wrap_method(
-                self.stop_cluster, default_timeout=None, client_info=client_info,
+                self.stop_cluster,
+                default_timeout=None,
+                client_info=client_info,
             ),
             self.start_cluster: gapic_v1.method.wrap_method(
-                self.start_cluster, default_timeout=None, client_info=client_info,
+                self.start_cluster,
+                default_timeout=None,
+                client_info=client_info,
             ),
             self.delete_cluster: gapic_v1.method.wrap_method(
                 self.delete_cluster,
@@ -219,9 +225,9 @@ class ClusterControllerTransport(abc.ABC):
     def close(self):
         """Closes resources associated with the transport.
 
-       .. warning::
-            Only call this method if the transport is NOT shared
-            with other clients - this may cause errors in other clients!
+        .. warning::
+             Only call this method if the transport is NOT shared
+             with other clients - this may cause errors in other clients!
         """
         raise NotImplementedError()
 

--- a/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc.py
+++ b/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc.py
@@ -228,8 +228,7 @@ class ClusterControllerGrpcTransport(ClusterControllerTransport):
 
     @property
     def grpc_channel(self) -> grpc.Channel:
-        """Return the channel designed to connect to this service.
-        """
+        """Return the channel designed to connect to this service."""
         return self._grpc_channel
 
     @property

--- a/google/cloud/dataproc_v1/services/job_controller/async_client.py
+++ b/google/cloud/dataproc_v1/services/job_controller/async_client.py
@@ -312,7 +312,12 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -436,7 +441,12 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -560,7 +570,12 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -694,12 +709,20 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListJobsAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -775,7 +798,12 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -893,7 +921,12 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1000,7 +1033,10 @@ class JobControllerAsyncClient:
 
         # Send the request.
         await rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     async def __aenter__(self):
@@ -1012,7 +1048,9 @@ class JobControllerAsyncClient:
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/job_controller/client.py
+++ b/google/cloud/dataproc_v1/services/job_controller/client.py
@@ -55,7 +55,10 @@ class JobControllerClientMeta(type):
     _transport_registry["grpc"] = JobControllerGrpcTransport
     _transport_registry["grpc_asyncio"] = JobControllerGrpcAsyncIOTransport
 
-    def get_transport_class(cls, label: str = None,) -> Type[JobControllerTransport]:
+    def get_transport_class(
+        cls,
+        label: str = None,
+    ) -> Type[JobControllerTransport]:
         """Returns an appropriate transport class.
 
         Args:
@@ -160,7 +163,9 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         return self._transport
 
     @staticmethod
-    def common_billing_account_path(billing_account: str,) -> str:
+    def common_billing_account_path(
+        billing_account: str,
+    ) -> str:
         """Returns a fully-qualified billing_account string."""
         return "billingAccounts/{billing_account}".format(
             billing_account=billing_account,
@@ -173,9 +178,13 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_folder_path(folder: str,) -> str:
+    def common_folder_path(
+        folder: str,
+    ) -> str:
         """Returns a fully-qualified folder string."""
-        return "folders/{folder}".format(folder=folder,)
+        return "folders/{folder}".format(
+            folder=folder,
+        )
 
     @staticmethod
     def parse_common_folder_path(path: str) -> Dict[str, str]:
@@ -184,9 +193,13 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_organization_path(organization: str,) -> str:
+    def common_organization_path(
+        organization: str,
+    ) -> str:
         """Returns a fully-qualified organization string."""
-        return "organizations/{organization}".format(organization=organization,)
+        return "organizations/{organization}".format(
+            organization=organization,
+        )
 
     @staticmethod
     def parse_common_organization_path(path: str) -> Dict[str, str]:
@@ -195,9 +208,13 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_project_path(project: str,) -> str:
+    def common_project_path(
+        project: str,
+    ) -> str:
         """Returns a fully-qualified project string."""
-        return "projects/{project}".format(project=project,)
+        return "projects/{project}".format(
+            project=project,
+        )
 
     @staticmethod
     def parse_common_project_path(path: str) -> Dict[str, str]:
@@ -206,10 +223,14 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_location_path(project: str, location: str,) -> str:
+    def common_location_path(
+        project: str,
+        location: str,
+    ) -> str:
         """Returns a fully-qualified location string."""
         return "projects/{project}/locations/{location}".format(
-            project=project, location=location,
+            project=project,
+            location=location,
         )
 
     @staticmethod
@@ -485,7 +506,12 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.submit_job]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -601,7 +627,12 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.submit_job_as_operation]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -715,7 +746,12 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.get_job]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -839,12 +875,20 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.list_jobs]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListJobsPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -913,7 +957,12 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.update_job]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1021,7 +1070,12 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.cancel_job]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1120,7 +1174,10 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
 
         # Send the request.
         rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     def __enter__(self):
@@ -1139,7 +1196,9 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/job_controller/transports/base.py
+++ b/google/cloud/dataproc_v1/services/job_controller/transports/base.py
@@ -32,7 +32,9 @@ from google.protobuf import empty_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
@@ -230,9 +232,9 @@ class JobControllerTransport(abc.ABC):
     def close(self):
         """Closes resources associated with the transport.
 
-       .. warning::
-            Only call this method if the transport is NOT shared
-            with other clients - this may cause errors in other clients!
+        .. warning::
+             Only call this method if the transport is NOT shared
+             with other clients - this may cause errors in other clients!
         """
         raise NotImplementedError()
 

--- a/google/cloud/dataproc_v1/services/job_controller/transports/grpc.py
+++ b/google/cloud/dataproc_v1/services/job_controller/transports/grpc.py
@@ -228,8 +228,7 @@ class JobControllerGrpcTransport(JobControllerTransport):
 
     @property
     def grpc_channel(self) -> grpc.Channel:
-        """Return the channel designed to connect to this service.
-        """
+        """Return the channel designed to connect to this service."""
         return self._grpc_channel
 
     @property

--- a/google/cloud/dataproc_v1/services/workflow_template_service/async_client.py
+++ b/google/cloud/dataproc_v1/services/workflow_template_service/async_client.py
@@ -343,7 +343,12 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -458,7 +463,12 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -625,7 +635,12 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -806,7 +821,12 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -926,7 +946,12 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1043,12 +1068,20 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListWorkflowTemplatesAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -1155,7 +1188,10 @@ class WorkflowTemplateServiceAsyncClient:
 
         # Send the request.
         await rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     async def __aenter__(self):
@@ -1167,7 +1203,9 @@ class WorkflowTemplateServiceAsyncClient:
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/workflow_template_service/client.py
+++ b/google/cloud/dataproc_v1/services/workflow_template_service/client.py
@@ -61,7 +61,8 @@ class WorkflowTemplateServiceClientMeta(type):
     _transport_registry["grpc_asyncio"] = WorkflowTemplateServiceGrpcAsyncIOTransport
 
     def get_transport_class(
-        cls, label: str = None,
+        cls,
+        label: str = None,
     ) -> Type[WorkflowTemplateServiceTransport]:
         """Returns an appropriate transport class.
 
@@ -169,10 +170,16 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return self._transport
 
     @staticmethod
-    def cluster_path(project: str, location: str, cluster: str,) -> str:
+    def cluster_path(
+        project: str,
+        location: str,
+        cluster: str,
+    ) -> str:
         """Returns a fully-qualified cluster string."""
         return "projects/{project}/locations/{location}/clusters/{cluster}".format(
-            project=project, location=location, cluster=cluster,
+            project=project,
+            location=location,
+            cluster=cluster,
         )
 
     @staticmethod
@@ -185,10 +192,16 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def service_path(project: str, location: str, service: str,) -> str:
+    def service_path(
+        project: str,
+        location: str,
+        service: str,
+    ) -> str:
         """Returns a fully-qualified service string."""
         return "projects/{project}/locations/{location}/services/{service}".format(
-            project=project, location=location, service=service,
+            project=project,
+            location=location,
+            service=service,
         )
 
     @staticmethod
@@ -202,11 +215,15 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
 
     @staticmethod
     def workflow_template_path(
-        project: str, region: str, workflow_template: str,
+        project: str,
+        region: str,
+        workflow_template: str,
     ) -> str:
         """Returns a fully-qualified workflow_template string."""
         return "projects/{project}/regions/{region}/workflowTemplates/{workflow_template}".format(
-            project=project, region=region, workflow_template=workflow_template,
+            project=project,
+            region=region,
+            workflow_template=workflow_template,
         )
 
     @staticmethod
@@ -219,7 +236,9 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_billing_account_path(billing_account: str,) -> str:
+    def common_billing_account_path(
+        billing_account: str,
+    ) -> str:
         """Returns a fully-qualified billing_account string."""
         return "billingAccounts/{billing_account}".format(
             billing_account=billing_account,
@@ -232,9 +251,13 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_folder_path(folder: str,) -> str:
+    def common_folder_path(
+        folder: str,
+    ) -> str:
         """Returns a fully-qualified folder string."""
-        return "folders/{folder}".format(folder=folder,)
+        return "folders/{folder}".format(
+            folder=folder,
+        )
 
     @staticmethod
     def parse_common_folder_path(path: str) -> Dict[str, str]:
@@ -243,9 +266,13 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_organization_path(organization: str,) -> str:
+    def common_organization_path(
+        organization: str,
+    ) -> str:
         """Returns a fully-qualified organization string."""
-        return "organizations/{organization}".format(organization=organization,)
+        return "organizations/{organization}".format(
+            organization=organization,
+        )
 
     @staticmethod
     def parse_common_organization_path(path: str) -> Dict[str, str]:
@@ -254,9 +281,13 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_project_path(project: str,) -> str:
+    def common_project_path(
+        project: str,
+    ) -> str:
         """Returns a fully-qualified project string."""
-        return "projects/{project}".format(project=project,)
+        return "projects/{project}".format(
+            project=project,
+        )
 
     @staticmethod
     def parse_common_project_path(path: str) -> Dict[str, str]:
@@ -265,10 +296,14 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_location_path(project: str, location: str,) -> str:
+    def common_location_path(
+        project: str,
+        location: str,
+    ) -> str:
         """Returns a fully-qualified location string."""
         return "projects/{project}/locations/{location}".format(
-            project=project, location=location,
+            project=project,
+            location=location,
         )
 
     @staticmethod
@@ -555,7 +590,12 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -660,7 +700,12 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -822,7 +867,12 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -1001,7 +1051,12 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -1113,7 +1168,12 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1220,12 +1280,20 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListWorkflowTemplatesPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -1324,7 +1392,10 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
 
         # Send the request.
         rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     def __enter__(self):
@@ -1343,7 +1414,9 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/workflow_template_service/transports/base.py
+++ b/google/cloud/dataproc_v1/services/workflow_template_service/transports/base.py
@@ -32,7 +32,9 @@ from google.protobuf import empty_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
@@ -228,9 +230,9 @@ class WorkflowTemplateServiceTransport(abc.ABC):
     def close(self):
         """Closes resources associated with the transport.
 
-       .. warning::
-            Only call this method if the transport is NOT shared
-            with other clients - this may cause errors in other clients!
+        .. warning::
+             Only call this method if the transport is NOT shared
+             with other clients - this may cause errors in other clients!
         """
         raise NotImplementedError()
 

--- a/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc.py
+++ b/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc.py
@@ -229,8 +229,7 @@ class WorkflowTemplateServiceGrpcTransport(WorkflowTemplateServiceTransport):
 
     @property
     def grpc_channel(self) -> grpc.Channel:
-        """Return the channel designed to connect to this service.
-        """
+        """Return the channel designed to connect to this service."""
         return self._grpc_channel
 
     @property

--- a/google/cloud/dataproc_v1/types/autoscaling_policies.py
+++ b/google/cloud/dataproc_v1/types/autoscaling_policies.py
@@ -82,18 +82,35 @@ class AutoscalingPolicy(proto.Message):
             32 labels can be associated with an autoscaling policy.
     """
 
-    id = proto.Field(proto.STRING, number=1,)
-    name = proto.Field(proto.STRING, number=2,)
+    id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
     basic_algorithm = proto.Field(
-        proto.MESSAGE, number=3, oneof="algorithm", message="BasicAutoscalingAlgorithm",
+        proto.MESSAGE,
+        number=3,
+        oneof="algorithm",
+        message="BasicAutoscalingAlgorithm",
     )
     worker_config = proto.Field(
-        proto.MESSAGE, number=4, message="InstanceGroupAutoscalingPolicyConfig",
+        proto.MESSAGE,
+        number=4,
+        message="InstanceGroupAutoscalingPolicyConfig",
     )
     secondary_worker_config = proto.Field(
-        proto.MESSAGE, number=5, message="InstanceGroupAutoscalingPolicyConfig",
+        proto.MESSAGE,
+        number=5,
+        message="InstanceGroupAutoscalingPolicyConfig",
     )
-    labels = proto.MapField(proto.STRING, proto.STRING, number=6,)
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=6,
+    )
 
 
 class BasicAutoscalingAlgorithm(proto.Message):
@@ -111,10 +128,14 @@ class BasicAutoscalingAlgorithm(proto.Message):
     """
 
     yarn_config = proto.Field(
-        proto.MESSAGE, number=1, message="BasicYarnAutoscalingConfig",
+        proto.MESSAGE,
+        number=1,
+        message="BasicYarnAutoscalingConfig",
     )
     cooldown_period = proto.Field(
-        proto.MESSAGE, number=2, message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=2,
+        message=duration_pb2.Duration,
     )
 
 
@@ -175,12 +196,26 @@ class BasicYarnAutoscalingConfig(proto.Message):
     """
 
     graceful_decommission_timeout = proto.Field(
-        proto.MESSAGE, number=5, message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=5,
+        message=duration_pb2.Duration,
     )
-    scale_up_factor = proto.Field(proto.DOUBLE, number=1,)
-    scale_down_factor = proto.Field(proto.DOUBLE, number=2,)
-    scale_up_min_worker_fraction = proto.Field(proto.DOUBLE, number=3,)
-    scale_down_min_worker_fraction = proto.Field(proto.DOUBLE, number=4,)
+    scale_up_factor = proto.Field(
+        proto.DOUBLE,
+        number=1,
+    )
+    scale_down_factor = proto.Field(
+        proto.DOUBLE,
+        number=2,
+    )
+    scale_up_min_worker_fraction = proto.Field(
+        proto.DOUBLE,
+        number=3,
+    )
+    scale_down_min_worker_fraction = proto.Field(
+        proto.DOUBLE,
+        number=4,
+    )
 
 
 class InstanceGroupAutoscalingPolicyConfig(proto.Message):
@@ -225,9 +260,18 @@ class InstanceGroupAutoscalingPolicyConfig(proto.Message):
             only and no secondary workers.
     """
 
-    min_instances = proto.Field(proto.INT32, number=1,)
-    max_instances = proto.Field(proto.INT32, number=2,)
-    weight = proto.Field(proto.INT32, number=3,)
+    min_instances = proto.Field(
+        proto.INT32,
+        number=1,
+    )
+    max_instances = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    weight = proto.Field(
+        proto.INT32,
+        number=3,
+    )
 
 
 class CreateAutoscalingPolicyRequest(proto.Message):
@@ -250,8 +294,15 @@ class CreateAutoscalingPolicyRequest(proto.Message):
             Required. The autoscaling policy to create.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    policy = proto.Field(proto.MESSAGE, number=2, message="AutoscalingPolicy",)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    policy = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="AutoscalingPolicy",
+    )
 
 
 class GetAutoscalingPolicyRequest(proto.Message):
@@ -272,7 +323,10 @@ class GetAutoscalingPolicyRequest(proto.Message):
                ``projects/{project_id}/locations/{location}/autoscalingPolicies/{policy_id}``
     """
 
-    name = proto.Field(proto.STRING, number=1,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class UpdateAutoscalingPolicyRequest(proto.Message):
@@ -283,7 +337,11 @@ class UpdateAutoscalingPolicyRequest(proto.Message):
             Required. The updated autoscaling policy.
     """
 
-    policy = proto.Field(proto.MESSAGE, number=1, message="AutoscalingPolicy",)
+    policy = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message="AutoscalingPolicy",
+    )
 
 
 class DeleteAutoscalingPolicyRequest(proto.Message):
@@ -306,7 +364,10 @@ class DeleteAutoscalingPolicyRequest(proto.Message):
                ``projects/{project_id}/locations/{location}/autoscalingPolicies/{policy_id}``
     """
 
-    name = proto.Field(proto.STRING, number=1,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class ListAutoscalingPoliciesRequest(proto.Message):
@@ -335,9 +396,18 @@ class ListAutoscalingPoliciesRequest(proto.Message):
             results.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    page_size = proto.Field(proto.INT32, number=2,)
-    page_token = proto.Field(proto.STRING, number=3,)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    page_size = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    page_token = proto.Field(
+        proto.STRING,
+        number=3,
+    )
 
 
 class ListAutoscalingPoliciesResponse(proto.Message):
@@ -357,9 +427,14 @@ class ListAutoscalingPoliciesResponse(proto.Message):
         return self
 
     policies = proto.RepeatedField(
-        proto.MESSAGE, number=1, message="AutoscalingPolicy",
+        proto.MESSAGE,
+        number=1,
+        message="AutoscalingPolicy",
     )
-    next_page_token = proto.Field(proto.STRING, number=2,)
+    next_page_token = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/dataproc_v1/types/batches.py
+++ b/google/cloud/dataproc_v1/types/batches.py
@@ -67,10 +67,23 @@ class CreateBatchRequest(proto.Message):
             is 40 characters.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    batch = proto.Field(proto.MESSAGE, number=2, message="Batch",)
-    batch_id = proto.Field(proto.STRING, number=3,)
-    request_id = proto.Field(proto.STRING, number=4,)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    batch = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="Batch",
+    )
+    batch_id = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=4,
+    )
 
 
 class GetBatchRequest(proto.Message):
@@ -82,7 +95,10 @@ class GetBatchRequest(proto.Message):
             Required. The name of the batch to retrieve.
     """
 
-    name = proto.Field(proto.STRING, number=1,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class ListBatchesRequest(proto.Message):
@@ -103,9 +119,18 @@ class ListBatchesRequest(proto.Message):
             subsequent page.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    page_size = proto.Field(proto.INT32, number=2,)
-    page_token = proto.Field(proto.STRING, number=3,)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    page_size = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    page_token = proto.Field(
+        proto.STRING,
+        number=3,
+    )
 
 
 class ListBatchesResponse(proto.Message):
@@ -124,8 +149,15 @@ class ListBatchesResponse(proto.Message):
     def raw_page(self):
         return self
 
-    batches = proto.RepeatedField(proto.MESSAGE, number=1, message="Batch",)
-    next_page_token = proto.Field(proto.STRING, number=2,)
+    batches = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message="Batch",
+    )
+    next_page_token = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class DeleteBatchRequest(proto.Message):
@@ -137,7 +169,10 @@ class DeleteBatchRequest(proto.Message):
             delete.
     """
 
-    name = proto.Field(proto.STRING, number=1,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class Batch(proto.Message):
@@ -237,41 +272,105 @@ class Batch(proto.Message):
                 the historical state.
         """
 
-        state = proto.Field(proto.ENUM, number=1, enum="Batch.State",)
-        state_message = proto.Field(proto.STRING, number=2,)
+        state = proto.Field(
+            proto.ENUM,
+            number=1,
+            enum="Batch.State",
+        )
+        state_message = proto.Field(
+            proto.STRING,
+            number=2,
+        )
         state_start_time = proto.Field(
-            proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,
+            proto.MESSAGE,
+            number=3,
+            message=timestamp_pb2.Timestamp,
         )
 
-    name = proto.Field(proto.STRING, number=1,)
-    uuid = proto.Field(proto.STRING, number=2,)
-    create_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    uuid = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    create_time = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message=timestamp_pb2.Timestamp,
+    )
     pyspark_batch = proto.Field(
-        proto.MESSAGE, number=4, oneof="batch_config", message="PySparkBatch",
+        proto.MESSAGE,
+        number=4,
+        oneof="batch_config",
+        message="PySparkBatch",
     )
     spark_batch = proto.Field(
-        proto.MESSAGE, number=5, oneof="batch_config", message="SparkBatch",
+        proto.MESSAGE,
+        number=5,
+        oneof="batch_config",
+        message="SparkBatch",
     )
     spark_r_batch = proto.Field(
-        proto.MESSAGE, number=6, oneof="batch_config", message="SparkRBatch",
+        proto.MESSAGE,
+        number=6,
+        oneof="batch_config",
+        message="SparkRBatch",
     )
     spark_sql_batch = proto.Field(
-        proto.MESSAGE, number=7, oneof="batch_config", message="SparkSqlBatch",
+        proto.MESSAGE,
+        number=7,
+        oneof="batch_config",
+        message="SparkSqlBatch",
     )
-    runtime_info = proto.Field(proto.MESSAGE, number=8, message=shared.RuntimeInfo,)
-    state = proto.Field(proto.ENUM, number=9, enum=State,)
-    state_message = proto.Field(proto.STRING, number=10,)
-    state_time = proto.Field(proto.MESSAGE, number=11, message=timestamp_pb2.Timestamp,)
-    creator = proto.Field(proto.STRING, number=12,)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=13,)
+    runtime_info = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message=shared.RuntimeInfo,
+    )
+    state = proto.Field(
+        proto.ENUM,
+        number=9,
+        enum=State,
+    )
+    state_message = proto.Field(
+        proto.STRING,
+        number=10,
+    )
+    state_time = proto.Field(
+        proto.MESSAGE,
+        number=11,
+        message=timestamp_pb2.Timestamp,
+    )
+    creator = proto.Field(
+        proto.STRING,
+        number=12,
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=13,
+    )
     runtime_config = proto.Field(
-        proto.MESSAGE, number=14, message=shared.RuntimeConfig,
+        proto.MESSAGE,
+        number=14,
+        message=shared.RuntimeConfig,
     )
     environment_config = proto.Field(
-        proto.MESSAGE, number=15, message=shared.EnvironmentConfig,
+        proto.MESSAGE,
+        number=15,
+        message=shared.EnvironmentConfig,
     )
-    operation = proto.Field(proto.STRING, number=16,)
-    state_history = proto.RepeatedField(proto.MESSAGE, number=17, message=StateHistory,)
+    operation = proto.Field(
+        proto.STRING,
+        number=16,
+    )
+    state_history = proto.RepeatedField(
+        proto.MESSAGE,
+        number=17,
+        message=StateHistory,
+    )
 
 
 class PySparkBatch(proto.Message):
@@ -305,12 +404,30 @@ class PySparkBatch(proto.Message):
             ``.jar``, ``.tar``, ``.tar.gz``, ``.tgz``, and ``.zip``.
     """
 
-    main_python_file_uri = proto.Field(proto.STRING, number=1,)
-    args = proto.RepeatedField(proto.STRING, number=2,)
-    python_file_uris = proto.RepeatedField(proto.STRING, number=3,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=4,)
-    file_uris = proto.RepeatedField(proto.STRING, number=5,)
-    archive_uris = proto.RepeatedField(proto.STRING, number=6,)
+    main_python_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    args = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    python_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=5,
+    )
+    archive_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
 
 
 class SparkBatch(proto.Message):
@@ -353,12 +470,32 @@ class SparkBatch(proto.Message):
             ``.jar``, ``.tar``, ``.tar.gz``, ``.tgz``, and ``.zip``.
     """
 
-    main_jar_file_uri = proto.Field(proto.STRING, number=1, oneof="driver",)
-    main_class = proto.Field(proto.STRING, number=2, oneof="driver",)
-    args = proto.RepeatedField(proto.STRING, number=3,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=4,)
-    file_uris = proto.RepeatedField(proto.STRING, number=5,)
-    archive_uris = proto.RepeatedField(proto.STRING, number=6,)
+    main_jar_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="driver",
+    )
+    main_class = proto.Field(
+        proto.STRING,
+        number=2,
+        oneof="driver",
+    )
+    args = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=5,
+    )
+    archive_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
 
 
 class SparkRBatch(proto.Message):
@@ -384,10 +521,22 @@ class SparkRBatch(proto.Message):
             ``.jar``, ``.tar``, ``.tar.gz``, ``.tgz``, and ``.zip``.
     """
 
-    main_r_file_uri = proto.Field(proto.STRING, number=1,)
-    args = proto.RepeatedField(proto.STRING, number=2,)
-    file_uris = proto.RepeatedField(proto.STRING, number=3,)
-    archive_uris = proto.RepeatedField(proto.STRING, number=4,)
+    main_r_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    args = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    archive_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
 
 
 class SparkSqlBatch(proto.Message):
@@ -407,9 +556,19 @@ class SparkSqlBatch(proto.Message):
             to the Spark CLASSPATH.
     """
 
-    query_file_uri = proto.Field(proto.STRING, number=1,)
-    query_variables = proto.MapField(proto.STRING, proto.STRING, number=2,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=3,)
+    query_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    query_variables = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=2,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/dataproc_v1/types/clusters.py
+++ b/google/cloud/dataproc_v1/types/clusters.py
@@ -103,16 +103,43 @@ class Cluster(proto.Message):
             purposes only. It may be changed before final release.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    cluster_name = proto.Field(proto.STRING, number=2,)
-    config = proto.Field(proto.MESSAGE, number=3, message="ClusterConfig",)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=8,)
-    status = proto.Field(proto.MESSAGE, number=4, message="ClusterStatus",)
-    status_history = proto.RepeatedField(
-        proto.MESSAGE, number=7, message="ClusterStatus",
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
     )
-    cluster_uuid = proto.Field(proto.STRING, number=6,)
-    metrics = proto.Field(proto.MESSAGE, number=9, message="ClusterMetrics",)
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    config = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message="ClusterConfig",
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=8,
+    )
+    status = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message="ClusterStatus",
+    )
+    status_history = proto.RepeatedField(
+        proto.MESSAGE,
+        number=7,
+        message="ClusterStatus",
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=6,
+    )
+    metrics = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message="ClusterMetrics",
+    )
 
 
 class ClusterConfig(proto.Message):
@@ -201,34 +228,78 @@ class ClusterConfig(proto.Message):
             ``autoscaling_config``.
     """
 
-    config_bucket = proto.Field(proto.STRING, number=1,)
-    temp_bucket = proto.Field(proto.STRING, number=2,)
-    gce_cluster_config = proto.Field(
-        proto.MESSAGE, number=8, message="GceClusterConfig",
+    config_bucket = proto.Field(
+        proto.STRING,
+        number=1,
     )
-    master_config = proto.Field(proto.MESSAGE, number=9, message="InstanceGroupConfig",)
+    temp_bucket = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    gce_cluster_config = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message="GceClusterConfig",
+    )
+    master_config = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message="InstanceGroupConfig",
+    )
     worker_config = proto.Field(
-        proto.MESSAGE, number=10, message="InstanceGroupConfig",
+        proto.MESSAGE,
+        number=10,
+        message="InstanceGroupConfig",
     )
     secondary_worker_config = proto.Field(
-        proto.MESSAGE, number=12, message="InstanceGroupConfig",
+        proto.MESSAGE,
+        number=12,
+        message="InstanceGroupConfig",
     )
-    software_config = proto.Field(proto.MESSAGE, number=13, message="SoftwareConfig",)
+    software_config = proto.Field(
+        proto.MESSAGE,
+        number=13,
+        message="SoftwareConfig",
+    )
     initialization_actions = proto.RepeatedField(
-        proto.MESSAGE, number=11, message="NodeInitializationAction",
+        proto.MESSAGE,
+        number=11,
+        message="NodeInitializationAction",
     )
     encryption_config = proto.Field(
-        proto.MESSAGE, number=15, message="EncryptionConfig",
+        proto.MESSAGE,
+        number=15,
+        message="EncryptionConfig",
     )
     autoscaling_config = proto.Field(
-        proto.MESSAGE, number=18, message="AutoscalingConfig",
+        proto.MESSAGE,
+        number=18,
+        message="AutoscalingConfig",
     )
-    security_config = proto.Field(proto.MESSAGE, number=16, message="SecurityConfig",)
-    lifecycle_config = proto.Field(proto.MESSAGE, number=17, message="LifecycleConfig",)
-    endpoint_config = proto.Field(proto.MESSAGE, number=19, message="EndpointConfig",)
-    metastore_config = proto.Field(proto.MESSAGE, number=20, message="MetastoreConfig",)
+    security_config = proto.Field(
+        proto.MESSAGE,
+        number=16,
+        message="SecurityConfig",
+    )
+    lifecycle_config = proto.Field(
+        proto.MESSAGE,
+        number=17,
+        message="LifecycleConfig",
+    )
+    endpoint_config = proto.Field(
+        proto.MESSAGE,
+        number=19,
+        message="EndpointConfig",
+    )
+    metastore_config = proto.Field(
+        proto.MESSAGE,
+        number=20,
+        message="MetastoreConfig",
+    )
     gke_cluster_config = proto.Field(
-        proto.MESSAGE, number=21, message="GkeClusterConfig",
+        proto.MESSAGE,
+        number=21,
+        message="GkeClusterConfig",
     )
 
 
@@ -253,11 +324,19 @@ class GkeClusterConfig(proto.Message):
                 to deploy into.
         """
 
-        target_gke_cluster = proto.Field(proto.STRING, number=1,)
-        cluster_namespace = proto.Field(proto.STRING, number=2,)
+        target_gke_cluster = proto.Field(
+            proto.STRING,
+            number=1,
+        )
+        cluster_namespace = proto.Field(
+            proto.STRING,
+            number=2,
+        )
 
     namespaced_gke_deployment_target = proto.Field(
-        proto.MESSAGE, number=1, message=NamespacedGkeDeploymentTarget,
+        proto.MESSAGE,
+        number=1,
+        message=NamespacedGkeDeploymentTarget,
     )
 
 
@@ -274,8 +353,15 @@ class EndpointConfig(proto.Message):
             sources. Defaults to false.
     """
 
-    http_ports = proto.MapField(proto.STRING, proto.STRING, number=1,)
-    enable_http_port_access = proto.Field(proto.BOOL, number=2,)
+    http_ports = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=1,
+    )
+    enable_http_port_access = proto.Field(
+        proto.BOOL,
+        number=2,
+    )
 
 
 class AutoscalingConfig(proto.Message):
@@ -295,7 +381,10 @@ class AutoscalingConfig(proto.Message):
             Dataproc region.
     """
 
-    policy_uri = proto.Field(proto.STRING, number=1,)
+    policy_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class EncryptionConfig(proto.Message):
@@ -308,7 +397,10 @@ class EncryptionConfig(proto.Message):
             cluster.
     """
 
-    gce_pd_kms_key_name = proto.Field(proto.STRING, number=1,)
+    gce_pd_kms_key_name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class GceClusterConfig(proto.Message):
@@ -427,28 +519,63 @@ class GceClusterConfig(proto.Message):
         OUTBOUND = 2
         BIDIRECTIONAL = 3
 
-    zone_uri = proto.Field(proto.STRING, number=1,)
-    network_uri = proto.Field(proto.STRING, number=2,)
-    subnetwork_uri = proto.Field(proto.STRING, number=6,)
-    internal_ip_only = proto.Field(proto.BOOL, number=7,)
-    private_ipv6_google_access = proto.Field(
-        proto.ENUM, number=12, enum=PrivateIpv6GoogleAccess,
+    zone_uri = proto.Field(
+        proto.STRING,
+        number=1,
     )
-    service_account = proto.Field(proto.STRING, number=8,)
-    service_account_scopes = proto.RepeatedField(proto.STRING, number=3,)
-    tags = proto.RepeatedField(proto.STRING, number=4,)
-    metadata = proto.MapField(proto.STRING, proto.STRING, number=5,)
+    network_uri = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    subnetwork_uri = proto.Field(
+        proto.STRING,
+        number=6,
+    )
+    internal_ip_only = proto.Field(
+        proto.BOOL,
+        number=7,
+    )
+    private_ipv6_google_access = proto.Field(
+        proto.ENUM,
+        number=12,
+        enum=PrivateIpv6GoogleAccess,
+    )
+    service_account = proto.Field(
+        proto.STRING,
+        number=8,
+    )
+    service_account_scopes = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    tags = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    metadata = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=5,
+    )
     reservation_affinity = proto.Field(
-        proto.MESSAGE, number=11, message="ReservationAffinity",
+        proto.MESSAGE,
+        number=11,
+        message="ReservationAffinity",
     )
     node_group_affinity = proto.Field(
-        proto.MESSAGE, number=13, message="NodeGroupAffinity",
+        proto.MESSAGE,
+        number=13,
+        message="NodeGroupAffinity",
     )
     shielded_instance_config = proto.Field(
-        proto.MESSAGE, number=14, message="ShieldedInstanceConfig",
+        proto.MESSAGE,
+        number=14,
+        message="ShieldedInstanceConfig",
     )
     confidential_instance_config = proto.Field(
-        proto.MESSAGE, number=15, message="ConfidentialInstanceConfig",
+        proto.MESSAGE,
+        number=15,
+        message="ConfidentialInstanceConfig",
     )
 
 
@@ -470,7 +597,10 @@ class NodeGroupAffinity(proto.Message):
             -  ``node-group-1``
     """
 
-    node_group_uri = proto.Field(proto.STRING, number=1,)
+    node_group_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class ShieldedInstanceConfig(proto.Message):
@@ -489,9 +619,18 @@ class ShieldedInstanceConfig(proto.Message):
             integrity monitoring enabled.
     """
 
-    enable_secure_boot = proto.Field(proto.BOOL, number=1,)
-    enable_vtpm = proto.Field(proto.BOOL, number=2,)
-    enable_integrity_monitoring = proto.Field(proto.BOOL, number=3,)
+    enable_secure_boot = proto.Field(
+        proto.BOOL,
+        number=1,
+    )
+    enable_vtpm = proto.Field(
+        proto.BOOL,
+        number=2,
+    )
+    enable_integrity_monitoring = proto.Field(
+        proto.BOOL,
+        number=3,
+    )
 
 
 class ConfidentialInstanceConfig(proto.Message):
@@ -504,7 +643,10 @@ class ConfidentialInstanceConfig(proto.Message):
             have confidential compute enabled.
     """
 
-    enable_confidential_compute = proto.Field(proto.BOOL, number=1,)
+    enable_confidential_compute = proto.Field(
+        proto.BOOL,
+        number=1,
+    )
 
 
 class InstanceGroupConfig(proto.Message):
@@ -596,20 +738,50 @@ class InstanceGroupConfig(proto.Message):
         NON_PREEMPTIBLE = 1
         PREEMPTIBLE = 2
 
-    num_instances = proto.Field(proto.INT32, number=1,)
-    instance_names = proto.RepeatedField(proto.STRING, number=2,)
-    image_uri = proto.Field(proto.STRING, number=3,)
-    machine_type_uri = proto.Field(proto.STRING, number=4,)
-    disk_config = proto.Field(proto.MESSAGE, number=5, message="DiskConfig",)
-    is_preemptible = proto.Field(proto.BOOL, number=6,)
-    preemptibility = proto.Field(proto.ENUM, number=10, enum=Preemptibility,)
+    num_instances = proto.Field(
+        proto.INT32,
+        number=1,
+    )
+    instance_names = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    image_uri = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    machine_type_uri = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    disk_config = proto.Field(
+        proto.MESSAGE,
+        number=5,
+        message="DiskConfig",
+    )
+    is_preemptible = proto.Field(
+        proto.BOOL,
+        number=6,
+    )
+    preemptibility = proto.Field(
+        proto.ENUM,
+        number=10,
+        enum=Preemptibility,
+    )
     managed_group_config = proto.Field(
-        proto.MESSAGE, number=7, message="ManagedGroupConfig",
+        proto.MESSAGE,
+        number=7,
+        message="ManagedGroupConfig",
     )
     accelerators = proto.RepeatedField(
-        proto.MESSAGE, number=8, message="AcceleratorConfig",
+        proto.MESSAGE,
+        number=8,
+        message="AcceleratorConfig",
     )
-    min_cpu_platform = proto.Field(proto.STRING, number=9,)
+    min_cpu_platform = proto.Field(
+        proto.STRING,
+        number=9,
+    )
 
 
 class ManagedGroupConfig(proto.Message):
@@ -625,8 +797,14 @@ class ManagedGroupConfig(proto.Message):
             Manager for this group.
     """
 
-    instance_template_name = proto.Field(proto.STRING, number=1,)
-    instance_group_manager_name = proto.Field(proto.STRING, number=2,)
+    instance_template_name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    instance_group_manager_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class AcceleratorConfig(proto.Message):
@@ -656,8 +834,14 @@ class AcceleratorConfig(proto.Message):
             type exposed to this instance.
     """
 
-    accelerator_type_uri = proto.Field(proto.STRING, number=1,)
-    accelerator_count = proto.Field(proto.INT32, number=2,)
+    accelerator_type_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    accelerator_count = proto.Field(
+        proto.INT32,
+        number=2,
+    )
 
 
 class DiskConfig(proto.Message):
@@ -690,10 +874,22 @@ class DiskConfig(proto.Message):
             types <https://cloud.google.com/compute/docs/disks/local-ssd#performance>`__.
     """
 
-    boot_disk_type = proto.Field(proto.STRING, number=3,)
-    boot_disk_size_gb = proto.Field(proto.INT32, number=1,)
-    num_local_ssds = proto.Field(proto.INT32, number=2,)
-    local_ssd_interface = proto.Field(proto.STRING, number=4,)
+    boot_disk_type = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    boot_disk_size_gb = proto.Field(
+        proto.INT32,
+        number=1,
+    )
+    num_local_ssds = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    local_ssd_interface = proto.Field(
+        proto.STRING,
+        number=4,
+    )
 
 
 class NodeInitializationAction(proto.Message):
@@ -715,9 +911,14 @@ class NodeInitializationAction(proto.Message):
             at end of the timeout period.
     """
 
-    executable_file = proto.Field(proto.STRING, number=1,)
+    executable_file = proto.Field(
+        proto.STRING,
+        number=1,
+    )
     execution_timeout = proto.Field(
-        proto.MESSAGE, number=2, message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=2,
+        message=duration_pb2.Duration,
     )
 
 
@@ -758,12 +959,25 @@ class ClusterStatus(proto.Message):
         UNHEALTHY = 1
         STALE_STATUS = 2
 
-    state = proto.Field(proto.ENUM, number=1, enum=State,)
-    detail = proto.Field(proto.STRING, number=2,)
-    state_start_time = proto.Field(
-        proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,
+    state = proto.Field(
+        proto.ENUM,
+        number=1,
+        enum=State,
     )
-    substate = proto.Field(proto.ENUM, number=4, enum=Substate,)
+    detail = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    state_start_time = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message=timestamp_pb2.Timestamp,
+    )
+    substate = proto.Field(
+        proto.ENUM,
+        number=4,
+        enum=Substate,
+    )
 
 
 class SecurityConfig(proto.Message):
@@ -779,8 +993,16 @@ class SecurityConfig(proto.Message):
             multi-tenancy user mappings.
     """
 
-    kerberos_config = proto.Field(proto.MESSAGE, number=1, message="KerberosConfig",)
-    identity_config = proto.Field(proto.MESSAGE, number=2, message="IdentityConfig",)
+    kerberos_config = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message="KerberosConfig",
+    )
+    identity_config = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="IdentityConfig",
+    )
 
 
 class KerberosConfig(proto.Message):
@@ -858,21 +1080,66 @@ class KerberosConfig(proto.Message):
             of hostnames will be the realm.
     """
 
-    enable_kerberos = proto.Field(proto.BOOL, number=1,)
-    root_principal_password_uri = proto.Field(proto.STRING, number=2,)
-    kms_key_uri = proto.Field(proto.STRING, number=3,)
-    keystore_uri = proto.Field(proto.STRING, number=4,)
-    truststore_uri = proto.Field(proto.STRING, number=5,)
-    keystore_password_uri = proto.Field(proto.STRING, number=6,)
-    key_password_uri = proto.Field(proto.STRING, number=7,)
-    truststore_password_uri = proto.Field(proto.STRING, number=8,)
-    cross_realm_trust_realm = proto.Field(proto.STRING, number=9,)
-    cross_realm_trust_kdc = proto.Field(proto.STRING, number=10,)
-    cross_realm_trust_admin_server = proto.Field(proto.STRING, number=11,)
-    cross_realm_trust_shared_password_uri = proto.Field(proto.STRING, number=12,)
-    kdc_db_key_uri = proto.Field(proto.STRING, number=13,)
-    tgt_lifetime_hours = proto.Field(proto.INT32, number=14,)
-    realm = proto.Field(proto.STRING, number=15,)
+    enable_kerberos = proto.Field(
+        proto.BOOL,
+        number=1,
+    )
+    root_principal_password_uri = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    kms_key_uri = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    keystore_uri = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    truststore_uri = proto.Field(
+        proto.STRING,
+        number=5,
+    )
+    keystore_password_uri = proto.Field(
+        proto.STRING,
+        number=6,
+    )
+    key_password_uri = proto.Field(
+        proto.STRING,
+        number=7,
+    )
+    truststore_password_uri = proto.Field(
+        proto.STRING,
+        number=8,
+    )
+    cross_realm_trust_realm = proto.Field(
+        proto.STRING,
+        number=9,
+    )
+    cross_realm_trust_kdc = proto.Field(
+        proto.STRING,
+        number=10,
+    )
+    cross_realm_trust_admin_server = proto.Field(
+        proto.STRING,
+        number=11,
+    )
+    cross_realm_trust_shared_password_uri = proto.Field(
+        proto.STRING,
+        number=12,
+    )
+    kdc_db_key_uri = proto.Field(
+        proto.STRING,
+        number=13,
+    )
+    tgt_lifetime_hours = proto.Field(
+        proto.INT32,
+        number=14,
+    )
+    realm = proto.Field(
+        proto.STRING,
+        number=15,
+    )
 
 
 class IdentityConfig(proto.Message):
@@ -884,7 +1151,11 @@ class IdentityConfig(proto.Message):
             Required. Map of user to service account.
     """
 
-    user_service_account_mapping = proto.MapField(proto.STRING, proto.STRING, number=1,)
+    user_service_account_mapping = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=1,
+    )
 
 
 class SoftwareConfig(proto.Message):
@@ -924,10 +1195,19 @@ class SoftwareConfig(proto.Message):
             on the cluster.
     """
 
-    image_version = proto.Field(proto.STRING, number=1,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=2,)
+    image_version = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=2,
+    )
     optional_components = proto.RepeatedField(
-        proto.ENUM, number=3, enum=shared.Component,
+        proto.ENUM,
+        number=3,
+        enum=shared.Component,
     )
 
 
@@ -971,16 +1251,26 @@ class LifecycleConfig(proto.Message):
     """
 
     idle_delete_ttl = proto.Field(
-        proto.MESSAGE, number=1, message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=1,
+        message=duration_pb2.Duration,
     )
     auto_delete_time = proto.Field(
-        proto.MESSAGE, number=2, oneof="ttl", message=timestamp_pb2.Timestamp,
+        proto.MESSAGE,
+        number=2,
+        oneof="ttl",
+        message=timestamp_pb2.Timestamp,
     )
     auto_delete_ttl = proto.Field(
-        proto.MESSAGE, number=3, oneof="ttl", message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=3,
+        oneof="ttl",
+        message=duration_pb2.Duration,
     )
     idle_start_time = proto.Field(
-        proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,
+        proto.MESSAGE,
+        number=4,
+        message=timestamp_pb2.Timestamp,
     )
 
 
@@ -997,7 +1287,10 @@ class MetastoreConfig(proto.Message):
             -  ``projects/[project_id]/locations/[dataproc_region]/services/[service-name]``
     """
 
-    dataproc_metastore_service = proto.Field(proto.STRING, number=1,)
+    dataproc_metastore_service = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class ClusterMetrics(proto.Message):
@@ -1013,8 +1306,16 @@ class ClusterMetrics(proto.Message):
             The YARN metrics.
     """
 
-    hdfs_metrics = proto.MapField(proto.STRING, proto.INT64, number=1,)
-    yarn_metrics = proto.MapField(proto.STRING, proto.INT64, number=2,)
+    hdfs_metrics = proto.MapField(
+        proto.STRING,
+        proto.INT64,
+        number=1,
+    )
+    yarn_metrics = proto.MapField(
+        proto.STRING,
+        proto.INT64,
+        number=2,
+    )
 
 
 class CreateClusterRequest(proto.Message):
@@ -1049,12 +1350,27 @@ class CreateClusterRequest(proto.Message):
             creation fails.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    cluster = proto.Field(proto.MESSAGE, number=2, message="Cluster",)
-    request_id = proto.Field(proto.STRING, number=4,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="Cluster",
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=4,
+    )
     action_on_failed_primary_workers = proto.Field(
-        proto.ENUM, number=5, enum=shared.FailureAction,
+        proto.ENUM,
+        number=5,
+        enum=shared.FailureAction,
     )
 
 
@@ -1162,17 +1478,37 @@ class UpdateClusterRequest(proto.Message):
             characters.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=5,)
-    cluster_name = proto.Field(proto.STRING, number=2,)
-    cluster = proto.Field(proto.MESSAGE, number=3, message="Cluster",)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=5,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    cluster = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message="Cluster",
+    )
     graceful_decommission_timeout = proto.Field(
-        proto.MESSAGE, number=6, message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=6,
+        message=duration_pb2.Duration,
     )
     update_mask = proto.Field(
-        proto.MESSAGE, number=4, message=field_mask_pb2.FieldMask,
+        proto.MESSAGE,
+        number=4,
+        message=field_mask_pb2.FieldMask,
     )
-    request_id = proto.Field(proto.STRING, number=7,)
+    request_id = proto.Field(
+        proto.STRING,
+        number=7,
+    )
 
 
 class StopClusterRequest(proto.Message):
@@ -1208,11 +1544,26 @@ class StopClusterRequest(proto.Message):
             characters.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=2,)
-    cluster_name = proto.Field(proto.STRING, number=3,)
-    cluster_uuid = proto.Field(proto.STRING, number=4,)
-    request_id = proto.Field(proto.STRING, number=5,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=5,
+    )
 
 
 class StartClusterRequest(proto.Message):
@@ -1248,11 +1599,26 @@ class StartClusterRequest(proto.Message):
             characters.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=2,)
-    cluster_name = proto.Field(proto.STRING, number=3,)
-    cluster_uuid = proto.Field(proto.STRING, number=4,)
-    request_id = proto.Field(proto.STRING, number=5,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=5,
+    )
 
 
 class DeleteClusterRequest(proto.Message):
@@ -1288,11 +1654,26 @@ class DeleteClusterRequest(proto.Message):
             characters.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    cluster_name = proto.Field(proto.STRING, number=2,)
-    cluster_uuid = proto.Field(proto.STRING, number=4,)
-    request_id = proto.Field(proto.STRING, number=5,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=5,
+    )
 
 
 class GetClusterRequest(proto.Message):
@@ -1310,9 +1691,18 @@ class GetClusterRequest(proto.Message):
             Required. The cluster name.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    cluster_name = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class ListClustersRequest(proto.Message):
@@ -1353,11 +1743,26 @@ class ListClustersRequest(proto.Message):
             Optional. The standard List page token.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=4,)
-    filter = proto.Field(proto.STRING, number=5,)
-    page_size = proto.Field(proto.INT32, number=2,)
-    page_token = proto.Field(proto.STRING, number=3,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    filter = proto.Field(
+        proto.STRING,
+        number=5,
+    )
+    page_size = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    page_token = proto.Field(
+        proto.STRING,
+        number=3,
+    )
 
 
 class ListClustersResponse(proto.Message):
@@ -1377,8 +1782,15 @@ class ListClustersResponse(proto.Message):
     def raw_page(self):
         return self
 
-    clusters = proto.RepeatedField(proto.MESSAGE, number=1, message="Cluster",)
-    next_page_token = proto.Field(proto.STRING, number=2,)
+    clusters = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message="Cluster",
+    )
+    next_page_token = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class DiagnoseClusterRequest(proto.Message):
@@ -1395,9 +1807,18 @@ class DiagnoseClusterRequest(proto.Message):
             Required. The cluster name.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    cluster_name = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class DiagnoseClusterResults(proto.Message):
@@ -1411,7 +1832,10 @@ class DiagnoseClusterResults(proto.Message):
             diagnostics.
     """
 
-    output_uri = proto.Field(proto.STRING, number=1,)
+    output_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class ReservationAffinity(proto.Message):
@@ -1437,9 +1861,19 @@ class ReservationAffinity(proto.Message):
         ANY_RESERVATION = 2
         SPECIFIC_RESERVATION = 3
 
-    consume_reservation_type = proto.Field(proto.ENUM, number=1, enum=Type,)
-    key = proto.Field(proto.STRING, number=2,)
-    values = proto.RepeatedField(proto.STRING, number=3,)
+    consume_reservation_type = proto.Field(
+        proto.ENUM,
+        number=1,
+        enum=Type,
+    )
+    key = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    values = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/dataproc_v1/types/jobs.py
+++ b/google/cloud/dataproc_v1/types/jobs.py
@@ -77,7 +77,12 @@ class LoggingConfig(proto.Message):
         FATAL = 7
         OFF = 8
 
-    driver_log_levels = proto.MapField(proto.STRING, proto.ENUM, number=2, enum=Level,)
+    driver_log_levels = proto.MapField(
+        proto.STRING,
+        proto.ENUM,
+        number=2,
+        enum=Level,
+    )
 
 
 class HadoopJob(proto.Message):
@@ -137,14 +142,42 @@ class HadoopJob(proto.Message):
             execution.
     """
 
-    main_jar_file_uri = proto.Field(proto.STRING, number=1, oneof="driver",)
-    main_class = proto.Field(proto.STRING, number=2, oneof="driver",)
-    args = proto.RepeatedField(proto.STRING, number=3,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=4,)
-    file_uris = proto.RepeatedField(proto.STRING, number=5,)
-    archive_uris = proto.RepeatedField(proto.STRING, number=6,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=7,)
-    logging_config = proto.Field(proto.MESSAGE, number=8, message="LoggingConfig",)
+    main_jar_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="driver",
+    )
+    main_class = proto.Field(
+        proto.STRING,
+        number=2,
+        oneof="driver",
+    )
+    args = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=5,
+    )
+    archive_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=7,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message="LoggingConfig",
+    )
 
 
 class SparkJob(proto.Message):
@@ -199,14 +232,42 @@ class SparkJob(proto.Message):
             execution.
     """
 
-    main_jar_file_uri = proto.Field(proto.STRING, number=1, oneof="driver",)
-    main_class = proto.Field(proto.STRING, number=2, oneof="driver",)
-    args = proto.RepeatedField(proto.STRING, number=3,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=4,)
-    file_uris = proto.RepeatedField(proto.STRING, number=5,)
-    archive_uris = proto.RepeatedField(proto.STRING, number=6,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=7,)
-    logging_config = proto.Field(proto.MESSAGE, number=8, message="LoggingConfig",)
+    main_jar_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="driver",
+    )
+    main_class = proto.Field(
+        proto.STRING,
+        number=2,
+        oneof="driver",
+    )
+    args = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=5,
+    )
+    archive_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=7,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message="LoggingConfig",
+    )
 
 
 class PySparkJob(proto.Message):
@@ -252,14 +313,40 @@ class PySparkJob(proto.Message):
             execution.
     """
 
-    main_python_file_uri = proto.Field(proto.STRING, number=1,)
-    args = proto.RepeatedField(proto.STRING, number=2,)
-    python_file_uris = proto.RepeatedField(proto.STRING, number=3,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=4,)
-    file_uris = proto.RepeatedField(proto.STRING, number=5,)
-    archive_uris = proto.RepeatedField(proto.STRING, number=6,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=7,)
-    logging_config = proto.Field(proto.MESSAGE, number=8, message="LoggingConfig",)
+    main_python_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    args = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    python_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=5,
+    )
+    archive_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=7,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message="LoggingConfig",
+    )
 
 
 class QueryList(proto.Message):
@@ -286,7 +373,10 @@ class QueryList(proto.Message):
                 }
     """
 
-    queries = proto.RepeatedField(proto.STRING, number=1,)
+    queries = proto.RepeatedField(
+        proto.STRING,
+        number=1,
+    )
 
 
 class HiveJob(proto.Message):
@@ -330,14 +420,35 @@ class HiveJob(proto.Message):
             and UDFs.
     """
 
-    query_file_uri = proto.Field(proto.STRING, number=1, oneof="queries",)
-    query_list = proto.Field(
-        proto.MESSAGE, number=2, oneof="queries", message="QueryList",
+    query_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="queries",
     )
-    continue_on_failure = proto.Field(proto.BOOL, number=3,)
-    script_variables = proto.MapField(proto.STRING, proto.STRING, number=4,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=5,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=6,)
+    query_list = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        oneof="queries",
+        message="QueryList",
+    )
+    continue_on_failure = proto.Field(
+        proto.BOOL,
+        number=3,
+    )
+    script_variables = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=4,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=5,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
 
 
 class SparkSqlJob(proto.Message):
@@ -378,14 +489,36 @@ class SparkSqlJob(proto.Message):
             execution.
     """
 
-    query_file_uri = proto.Field(proto.STRING, number=1, oneof="queries",)
-    query_list = proto.Field(
-        proto.MESSAGE, number=2, oneof="queries", message="QueryList",
+    query_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="queries",
     )
-    script_variables = proto.MapField(proto.STRING, proto.STRING, number=3,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=4,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=56,)
-    logging_config = proto.Field(proto.MESSAGE, number=6, message="LoggingConfig",)
+    query_list = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        oneof="queries",
+        message="QueryList",
+    )
+    script_variables = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=3,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=4,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=56,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=6,
+        message="LoggingConfig",
+    )
 
 
 class PigJob(proto.Message):
@@ -431,15 +564,40 @@ class PigJob(proto.Message):
             execution.
     """
 
-    query_file_uri = proto.Field(proto.STRING, number=1, oneof="queries",)
-    query_list = proto.Field(
-        proto.MESSAGE, number=2, oneof="queries", message="QueryList",
+    query_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="queries",
     )
-    continue_on_failure = proto.Field(proto.BOOL, number=3,)
-    script_variables = proto.MapField(proto.STRING, proto.STRING, number=4,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=5,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=6,)
-    logging_config = proto.Field(proto.MESSAGE, number=7, message="LoggingConfig",)
+    query_list = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        oneof="queries",
+        message="QueryList",
+    )
+    continue_on_failure = proto.Field(
+        proto.BOOL,
+        number=3,
+    )
+    script_variables = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=4,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=5,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=7,
+        message="LoggingConfig",
+    )
 
 
 class SparkRJob(proto.Message):
@@ -478,12 +636,32 @@ class SparkRJob(proto.Message):
             execution.
     """
 
-    main_r_file_uri = proto.Field(proto.STRING, number=1,)
-    args = proto.RepeatedField(proto.STRING, number=2,)
-    file_uris = proto.RepeatedField(proto.STRING, number=3,)
-    archive_uris = proto.RepeatedField(proto.STRING, number=4,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=5,)
-    logging_config = proto.Field(proto.MESSAGE, number=6, message="LoggingConfig",)
+    main_r_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    args = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    archive_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=5,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=6,
+        message="LoggingConfig",
+    )
 
 
 class PrestoJob(proto.Message):
@@ -531,15 +709,39 @@ class PrestoJob(proto.Message):
             execution.
     """
 
-    query_file_uri = proto.Field(proto.STRING, number=1, oneof="queries",)
-    query_list = proto.Field(
-        proto.MESSAGE, number=2, oneof="queries", message="QueryList",
+    query_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="queries",
     )
-    continue_on_failure = proto.Field(proto.BOOL, number=3,)
-    output_format = proto.Field(proto.STRING, number=4,)
-    client_tags = proto.RepeatedField(proto.STRING, number=5,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=6,)
-    logging_config = proto.Field(proto.MESSAGE, number=7, message="LoggingConfig",)
+    query_list = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        oneof="queries",
+        message="QueryList",
+    )
+    continue_on_failure = proto.Field(
+        proto.BOOL,
+        number=3,
+    )
+    output_format = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    client_tags = proto.RepeatedField(
+        proto.STRING,
+        number=5,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=6,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=7,
+        message="LoggingConfig",
+    )
 
 
 class JobPlacement(proto.Message):
@@ -557,9 +759,19 @@ class JobPlacement(proto.Message):
             cluster where the job will be submitted.
     """
 
-    cluster_name = proto.Field(proto.STRING, number=1,)
-    cluster_uuid = proto.Field(proto.STRING, number=2,)
-    cluster_labels = proto.MapField(proto.STRING, proto.STRING, number=3,)
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    cluster_labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=3,
+    )
 
 
 class JobStatus(proto.Message):
@@ -601,12 +813,25 @@ class JobStatus(proto.Message):
         QUEUED = 2
         STALE_STATUS = 3
 
-    state = proto.Field(proto.ENUM, number=1, enum=State,)
-    details = proto.Field(proto.STRING, number=2,)
-    state_start_time = proto.Field(
-        proto.MESSAGE, number=6, message=timestamp_pb2.Timestamp,
+    state = proto.Field(
+        proto.ENUM,
+        number=1,
+        enum=State,
     )
-    substate = proto.Field(proto.ENUM, number=7, enum=Substate,)
+    details = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    state_start_time = proto.Field(
+        proto.MESSAGE,
+        number=6,
+        message=timestamp_pb2.Timestamp,
+    )
+    substate = proto.Field(
+        proto.ENUM,
+        number=7,
+        enum=Substate,
+    )
 
 
 class JobReference(proto.Message):
@@ -629,8 +854,14 @@ class JobReference(proto.Message):
             by the server.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    job_id = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class YarnApplication(proto.Message):
@@ -672,10 +903,23 @@ class YarnApplication(proto.Message):
         FAILED = 7
         KILLED = 8
 
-    name = proto.Field(proto.STRING, number=1,)
-    state = proto.Field(proto.ENUM, number=2, enum=State,)
-    progress = proto.Field(proto.FLOAT, number=3,)
-    tracking_url = proto.Field(proto.STRING, number=4,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    state = proto.Field(
+        proto.ENUM,
+        number=2,
+        enum=State,
+    )
+    progress = proto.Field(
+        proto.FLOAT,
+        number=3,
+    )
+    tracking_url = proto.Field(
+        proto.STRING,
+        number=4,
+    )
 
 
 class Job(proto.Message):
@@ -770,41 +1014,105 @@ class Job(proto.Message):
             will indicate if it was successful, failed, or cancelled.
     """
 
-    reference = proto.Field(proto.MESSAGE, number=1, message="JobReference",)
-    placement = proto.Field(proto.MESSAGE, number=2, message="JobPlacement",)
+    reference = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message="JobReference",
+    )
+    placement = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="JobPlacement",
+    )
     hadoop_job = proto.Field(
-        proto.MESSAGE, number=3, oneof="type_job", message="HadoopJob",
+        proto.MESSAGE,
+        number=3,
+        oneof="type_job",
+        message="HadoopJob",
     )
     spark_job = proto.Field(
-        proto.MESSAGE, number=4, oneof="type_job", message="SparkJob",
+        proto.MESSAGE,
+        number=4,
+        oneof="type_job",
+        message="SparkJob",
     )
     pyspark_job = proto.Field(
-        proto.MESSAGE, number=5, oneof="type_job", message="PySparkJob",
+        proto.MESSAGE,
+        number=5,
+        oneof="type_job",
+        message="PySparkJob",
     )
     hive_job = proto.Field(
-        proto.MESSAGE, number=6, oneof="type_job", message="HiveJob",
+        proto.MESSAGE,
+        number=6,
+        oneof="type_job",
+        message="HiveJob",
     )
-    pig_job = proto.Field(proto.MESSAGE, number=7, oneof="type_job", message="PigJob",)
+    pig_job = proto.Field(
+        proto.MESSAGE,
+        number=7,
+        oneof="type_job",
+        message="PigJob",
+    )
     spark_r_job = proto.Field(
-        proto.MESSAGE, number=21, oneof="type_job", message="SparkRJob",
+        proto.MESSAGE,
+        number=21,
+        oneof="type_job",
+        message="SparkRJob",
     )
     spark_sql_job = proto.Field(
-        proto.MESSAGE, number=12, oneof="type_job", message="SparkSqlJob",
+        proto.MESSAGE,
+        number=12,
+        oneof="type_job",
+        message="SparkSqlJob",
     )
     presto_job = proto.Field(
-        proto.MESSAGE, number=23, oneof="type_job", message="PrestoJob",
+        proto.MESSAGE,
+        number=23,
+        oneof="type_job",
+        message="PrestoJob",
     )
-    status = proto.Field(proto.MESSAGE, number=8, message="JobStatus",)
-    status_history = proto.RepeatedField(proto.MESSAGE, number=13, message="JobStatus",)
+    status = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message="JobStatus",
+    )
+    status_history = proto.RepeatedField(
+        proto.MESSAGE,
+        number=13,
+        message="JobStatus",
+    )
     yarn_applications = proto.RepeatedField(
-        proto.MESSAGE, number=9, message="YarnApplication",
+        proto.MESSAGE,
+        number=9,
+        message="YarnApplication",
     )
-    driver_output_resource_uri = proto.Field(proto.STRING, number=17,)
-    driver_control_files_uri = proto.Field(proto.STRING, number=15,)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=18,)
-    scheduling = proto.Field(proto.MESSAGE, number=20, message="JobScheduling",)
-    job_uuid = proto.Field(proto.STRING, number=22,)
-    done = proto.Field(proto.BOOL, number=24,)
+    driver_output_resource_uri = proto.Field(
+        proto.STRING,
+        number=17,
+    )
+    driver_control_files_uri = proto.Field(
+        proto.STRING,
+        number=15,
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=18,
+    )
+    scheduling = proto.Field(
+        proto.MESSAGE,
+        number=20,
+        message="JobScheduling",
+    )
+    job_uuid = proto.Field(
+        proto.STRING,
+        number=22,
+    )
+    done = proto.Field(
+        proto.BOOL,
+        number=24,
+    )
 
 
 class JobScheduling(proto.Message):
@@ -836,8 +1144,14 @@ class JobScheduling(proto.Message):
             jobs.
     """
 
-    max_failures_per_hour = proto.Field(proto.INT32, number=1,)
-    max_failures_total = proto.Field(proto.INT32, number=2,)
+    max_failures_per_hour = proto.Field(
+        proto.INT32,
+        number=1,
+    )
+    max_failures_total = proto.Field(
+        proto.INT32,
+        number=2,
+    )
 
 
 class SubmitJobRequest(proto.Message):
@@ -868,10 +1182,23 @@ class SubmitJobRequest(proto.Message):
             characters.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    job = proto.Field(proto.MESSAGE, number=2, message="Job",)
-    request_id = proto.Field(proto.STRING, number=4,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    job = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="Job",
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=4,
+    )
 
 
 class JobMetadata(proto.Message):
@@ -888,10 +1215,24 @@ class JobMetadata(proto.Message):
             Output only. Job submission time.
     """
 
-    job_id = proto.Field(proto.STRING, number=1,)
-    status = proto.Field(proto.MESSAGE, number=2, message="JobStatus",)
-    operation_type = proto.Field(proto.STRING, number=3,)
-    start_time = proto.Field(proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,)
+    job_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    status = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="JobStatus",
+    )
+    operation_type = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    start_time = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message=timestamp_pb2.Timestamp,
+    )
 
 
 class GetJobRequest(proto.Message):
@@ -909,9 +1250,18 @@ class GetJobRequest(proto.Message):
             Required. The job ID.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    job_id = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class ListJobsRequest(proto.Message):
@@ -966,13 +1316,35 @@ class ListJobsRequest(proto.Message):
         ACTIVE = 1
         NON_ACTIVE = 2
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=6,)
-    page_size = proto.Field(proto.INT32, number=2,)
-    page_token = proto.Field(proto.STRING, number=3,)
-    cluster_name = proto.Field(proto.STRING, number=4,)
-    job_state_matcher = proto.Field(proto.ENUM, number=5, enum=JobStateMatcher,)
-    filter = proto.Field(proto.STRING, number=7,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=6,
+    )
+    page_size = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    page_token = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    job_state_matcher = proto.Field(
+        proto.ENUM,
+        number=5,
+        enum=JobStateMatcher,
+    )
+    filter = proto.Field(
+        proto.STRING,
+        number=7,
+    )
 
 
 class UpdateJobRequest(proto.Message):
@@ -997,12 +1369,27 @@ class UpdateJobRequest(proto.Message):
             Currently, labels is the only field that can be updated.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=2,)
-    job_id = proto.Field(proto.STRING, number=3,)
-    job = proto.Field(proto.MESSAGE, number=4, message="Job",)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    job = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message="Job",
+    )
     update_mask = proto.Field(
-        proto.MESSAGE, number=5, message=field_mask_pb2.FieldMask,
+        proto.MESSAGE,
+        number=5,
+        message=field_mask_pb2.FieldMask,
     )
 
 
@@ -1023,8 +1410,15 @@ class ListJobsResponse(proto.Message):
     def raw_page(self):
         return self
 
-    jobs = proto.RepeatedField(proto.MESSAGE, number=1, message="Job",)
-    next_page_token = proto.Field(proto.STRING, number=2,)
+    jobs = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message="Job",
+    )
+    next_page_token = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class CancelJobRequest(proto.Message):
@@ -1041,9 +1435,18 @@ class CancelJobRequest(proto.Message):
             Required. The job ID.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    job_id = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class DeleteJobRequest(proto.Message):
@@ -1060,9 +1463,18 @@ class DeleteJobRequest(proto.Message):
             Required. The job ID.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    job_id = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/dataproc_v1/types/operations.py
+++ b/google/cloud/dataproc_v1/types/operations.py
@@ -56,14 +56,42 @@ class BatchOperationMetadata(proto.Message):
         BATCH_OPERATION_TYPE_UNSPECIFIED = 0
         BATCH = 1
 
-    batch = proto.Field(proto.STRING, number=1,)
-    batch_uuid = proto.Field(proto.STRING, number=2,)
-    create_time = proto.Field(proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,)
-    done_time = proto.Field(proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,)
-    operation_type = proto.Field(proto.ENUM, number=6, enum=BatchOperationType,)
-    description = proto.Field(proto.STRING, number=7,)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=8,)
-    warnings = proto.RepeatedField(proto.STRING, number=9,)
+    batch = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    batch_uuid = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    create_time = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message=timestamp_pb2.Timestamp,
+    )
+    done_time = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message=timestamp_pb2.Timestamp,
+    )
+    operation_type = proto.Field(
+        proto.ENUM,
+        number=6,
+        enum=BatchOperationType,
+    )
+    description = proto.Field(
+        proto.STRING,
+        number=7,
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=8,
+    )
+    warnings = proto.RepeatedField(
+        proto.STRING,
+        number=9,
+    )
 
 
 class ClusterOperationStatus(proto.Message):
@@ -90,11 +118,23 @@ class ClusterOperationStatus(proto.Message):
         RUNNING = 2
         DONE = 3
 
-    state = proto.Field(proto.ENUM, number=1, enum=State,)
-    inner_state = proto.Field(proto.STRING, number=2,)
-    details = proto.Field(proto.STRING, number=3,)
+    state = proto.Field(
+        proto.ENUM,
+        number=1,
+        enum=State,
+    )
+    inner_state = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    details = proto.Field(
+        proto.STRING,
+        number=3,
+    )
     state_start_time = proto.Field(
-        proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,
+        proto.MESSAGE,
+        number=4,
+        message=timestamp_pb2.Timestamp,
     )
 
 
@@ -123,16 +163,41 @@ class ClusterOperationMetadata(proto.Message):
             operation execution.
     """
 
-    cluster_name = proto.Field(proto.STRING, number=7,)
-    cluster_uuid = proto.Field(proto.STRING, number=8,)
-    status = proto.Field(proto.MESSAGE, number=9, message="ClusterOperationStatus",)
-    status_history = proto.RepeatedField(
-        proto.MESSAGE, number=10, message="ClusterOperationStatus",
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=7,
     )
-    operation_type = proto.Field(proto.STRING, number=11,)
-    description = proto.Field(proto.STRING, number=12,)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=13,)
-    warnings = proto.RepeatedField(proto.STRING, number=14,)
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=8,
+    )
+    status = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message="ClusterOperationStatus",
+    )
+    status_history = proto.RepeatedField(
+        proto.MESSAGE,
+        number=10,
+        message="ClusterOperationStatus",
+    )
+    operation_type = proto.Field(
+        proto.STRING,
+        number=11,
+    )
+    description = proto.Field(
+        proto.STRING,
+        number=12,
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=13,
+    )
+    warnings = proto.RepeatedField(
+        proto.STRING,
+        number=14,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/dataproc_v1/types/shared.py
+++ b/google/cloud/dataproc_v1/types/shared.py
@@ -73,9 +73,19 @@ class RuntimeConfig(proto.Message):
             execution.
     """
 
-    version = proto.Field(proto.STRING, number=1,)
-    container_image = proto.Field(proto.STRING, number=2,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=3,)
+    version = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    container_image = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=3,
+    )
 
 
 class EnvironmentConfig(proto.Message):
@@ -90,9 +100,15 @@ class EnvironmentConfig(proto.Message):
             workload has access to.
     """
 
-    execution_config = proto.Field(proto.MESSAGE, number=1, message="ExecutionConfig",)
+    execution_config = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message="ExecutionConfig",
+    )
     peripherals_config = proto.Field(
-        proto.MESSAGE, number=2, message="PeripheralsConfig",
+        proto.MESSAGE,
+        number=2,
+        message="PeripheralsConfig",
     )
 
 
@@ -127,11 +143,28 @@ class ExecutionConfig(proto.Message):
             encryption.
     """
 
-    service_account = proto.Field(proto.STRING, number=2,)
-    network_uri = proto.Field(proto.STRING, number=4, oneof="network",)
-    subnetwork_uri = proto.Field(proto.STRING, number=5, oneof="network",)
-    network_tags = proto.RepeatedField(proto.STRING, number=6,)
-    kms_key = proto.Field(proto.STRING, number=7,)
+    service_account = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    network_uri = proto.Field(
+        proto.STRING,
+        number=4,
+        oneof="network",
+    )
+    subnetwork_uri = proto.Field(
+        proto.STRING,
+        number=5,
+        oneof="network",
+    )
+    network_tags = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
+    kms_key = proto.Field(
+        proto.STRING,
+        number=7,
+    )
 
 
 class SparkHistoryServerConfig(proto.Message):
@@ -147,7 +180,10 @@ class SparkHistoryServerConfig(proto.Message):
             -  ``projects/[project_id]/regions/[region]/clusters/[cluster_name]``
     """
 
-    dataproc_cluster = proto.Field(proto.STRING, number=1,)
+    dataproc_cluster = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class PeripheralsConfig(proto.Message):
@@ -166,9 +202,14 @@ class PeripheralsConfig(proto.Message):
             configuration for the workload.
     """
 
-    metastore_service = proto.Field(proto.STRING, number=1,)
+    metastore_service = proto.Field(
+        proto.STRING,
+        number=1,
+    )
     spark_history_server_config = proto.Field(
-        proto.MESSAGE, number=2, message="SparkHistoryServerConfig",
+        proto.MESSAGE,
+        number=2,
+        message="SparkHistoryServerConfig",
     )
 
 
@@ -187,9 +228,19 @@ class RuntimeInfo(proto.Message):
             of the diagnostics tarball.
     """
 
-    endpoints = proto.MapField(proto.STRING, proto.STRING, number=1,)
-    output_uri = proto.Field(proto.STRING, number=2,)
-    diagnostic_output_uri = proto.Field(proto.STRING, number=3,)
+    endpoints = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=1,
+    )
+    output_uri = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    diagnostic_output_uri = proto.Field(
+        proto.STRING,
+        number=3,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/dataproc_v1/types/workflow_templates.py
+++ b/google/cloud/dataproc_v1/types/workflow_templates.py
@@ -123,20 +123,53 @@ class WorkflowTemplate(proto.Message):
             the cluster is deleted.
     """
 
-    id = proto.Field(proto.STRING, number=2,)
-    name = proto.Field(proto.STRING, number=1,)
-    version = proto.Field(proto.INT32, number=3,)
-    create_time = proto.Field(proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,)
-    update_time = proto.Field(proto.MESSAGE, number=5, message=timestamp_pb2.Timestamp,)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=6,)
+    id = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    version = proto.Field(
+        proto.INT32,
+        number=3,
+    )
+    create_time = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message=timestamp_pb2.Timestamp,
+    )
+    update_time = proto.Field(
+        proto.MESSAGE,
+        number=5,
+        message=timestamp_pb2.Timestamp,
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=6,
+    )
     placement = proto.Field(
-        proto.MESSAGE, number=7, message="WorkflowTemplatePlacement",
+        proto.MESSAGE,
+        number=7,
+        message="WorkflowTemplatePlacement",
     )
-    jobs = proto.RepeatedField(proto.MESSAGE, number=8, message="OrderedJob",)
+    jobs = proto.RepeatedField(
+        proto.MESSAGE,
+        number=8,
+        message="OrderedJob",
+    )
     parameters = proto.RepeatedField(
-        proto.MESSAGE, number=9, message="TemplateParameter",
+        proto.MESSAGE,
+        number=9,
+        message="TemplateParameter",
     )
-    dag_timeout = proto.Field(proto.MESSAGE, number=10, message=duration_pb2.Duration,)
+    dag_timeout = proto.Field(
+        proto.MESSAGE,
+        number=10,
+        message=duration_pb2.Duration,
+    )
 
 
 class WorkflowTemplatePlacement(proto.Message):
@@ -167,10 +200,16 @@ class WorkflowTemplatePlacement(proto.Message):
     """
 
     managed_cluster = proto.Field(
-        proto.MESSAGE, number=1, oneof="placement", message="ManagedCluster",
+        proto.MESSAGE,
+        number=1,
+        oneof="placement",
+        message="ManagedCluster",
     )
     cluster_selector = proto.Field(
-        proto.MESSAGE, number=2, oneof="placement", message="ClusterSelector",
+        proto.MESSAGE,
+        number=2,
+        oneof="placement",
+        message="ClusterSelector",
     )
 
 
@@ -204,9 +243,20 @@ class ManagedCluster(proto.Message):
             cluster.
     """
 
-    cluster_name = proto.Field(proto.STRING, number=2,)
-    config = proto.Field(proto.MESSAGE, number=3, message=clusters.ClusterConfig,)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=4,)
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    config = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message=clusters.ClusterConfig,
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=4,
+    )
 
 
 class ClusterSelector(proto.Message):
@@ -225,8 +275,15 @@ class ClusterSelector(proto.Message):
             have all labels to match.
     """
 
-    zone = proto.Field(proto.STRING, number=1,)
-    cluster_labels = proto.MapField(proto.STRING, proto.STRING, number=2,)
+    zone = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    cluster_labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=2,
+    )
 
 
 class OrderedJob(proto.Message):
@@ -305,34 +362,72 @@ class OrderedJob(proto.Message):
             workflow.
     """
 
-    step_id = proto.Field(proto.STRING, number=1,)
+    step_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
     hadoop_job = proto.Field(
-        proto.MESSAGE, number=2, oneof="job_type", message=gcd_jobs.HadoopJob,
+        proto.MESSAGE,
+        number=2,
+        oneof="job_type",
+        message=gcd_jobs.HadoopJob,
     )
     spark_job = proto.Field(
-        proto.MESSAGE, number=3, oneof="job_type", message=gcd_jobs.SparkJob,
+        proto.MESSAGE,
+        number=3,
+        oneof="job_type",
+        message=gcd_jobs.SparkJob,
     )
     pyspark_job = proto.Field(
-        proto.MESSAGE, number=4, oneof="job_type", message=gcd_jobs.PySparkJob,
+        proto.MESSAGE,
+        number=4,
+        oneof="job_type",
+        message=gcd_jobs.PySparkJob,
     )
     hive_job = proto.Field(
-        proto.MESSAGE, number=5, oneof="job_type", message=gcd_jobs.HiveJob,
+        proto.MESSAGE,
+        number=5,
+        oneof="job_type",
+        message=gcd_jobs.HiveJob,
     )
     pig_job = proto.Field(
-        proto.MESSAGE, number=6, oneof="job_type", message=gcd_jobs.PigJob,
+        proto.MESSAGE,
+        number=6,
+        oneof="job_type",
+        message=gcd_jobs.PigJob,
     )
     spark_r_job = proto.Field(
-        proto.MESSAGE, number=11, oneof="job_type", message=gcd_jobs.SparkRJob,
+        proto.MESSAGE,
+        number=11,
+        oneof="job_type",
+        message=gcd_jobs.SparkRJob,
     )
     spark_sql_job = proto.Field(
-        proto.MESSAGE, number=7, oneof="job_type", message=gcd_jobs.SparkSqlJob,
+        proto.MESSAGE,
+        number=7,
+        oneof="job_type",
+        message=gcd_jobs.SparkSqlJob,
     )
     presto_job = proto.Field(
-        proto.MESSAGE, number=12, oneof="job_type", message=gcd_jobs.PrestoJob,
+        proto.MESSAGE,
+        number=12,
+        oneof="job_type",
+        message=gcd_jobs.PrestoJob,
     )
-    labels = proto.MapField(proto.STRING, proto.STRING, number=8,)
-    scheduling = proto.Field(proto.MESSAGE, number=9, message=gcd_jobs.JobScheduling,)
-    prerequisite_step_ids = proto.RepeatedField(proto.STRING, number=10,)
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=8,
+    )
+    scheduling = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message=gcd_jobs.JobScheduling,
+    )
+    prerequisite_step_ids = proto.RepeatedField(
+        proto.STRING,
+        number=10,
+    )
 
 
 class TemplateParameter(proto.Message):
@@ -414,10 +509,23 @@ class TemplateParameter(proto.Message):
             this parameter's value.
     """
 
-    name = proto.Field(proto.STRING, number=1,)
-    fields = proto.RepeatedField(proto.STRING, number=2,)
-    description = proto.Field(proto.STRING, number=3,)
-    validation = proto.Field(proto.MESSAGE, number=4, message="ParameterValidation",)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    fields = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    description = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    validation = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message="ParameterValidation",
+    )
 
 
 class ParameterValidation(proto.Message):
@@ -442,10 +550,16 @@ class ParameterValidation(proto.Message):
     """
 
     regex = proto.Field(
-        proto.MESSAGE, number=1, oneof="validation_type", message="RegexValidation",
+        proto.MESSAGE,
+        number=1,
+        oneof="validation_type",
+        message="RegexValidation",
     )
     values = proto.Field(
-        proto.MESSAGE, number=2, oneof="validation_type", message="ValueValidation",
+        proto.MESSAGE,
+        number=2,
+        oneof="validation_type",
+        message="ValueValidation",
     )
 
 
@@ -460,7 +574,10 @@ class RegexValidation(proto.Message):
             matches are not sufficient).
     """
 
-    regexes = proto.RepeatedField(proto.STRING, number=1,)
+    regexes = proto.RepeatedField(
+        proto.STRING,
+        number=1,
+    )
 
 
 class ValueValidation(proto.Message):
@@ -472,7 +589,10 @@ class ValueValidation(proto.Message):
             parameter.
     """
 
-    values = proto.RepeatedField(proto.STRING, number=1,)
+    values = proto.RepeatedField(
+        proto.STRING,
+        number=1,
+    )
 
 
 class WorkflowMetadata(proto.Message):
@@ -536,23 +656,71 @@ class WorkflowMetadata(proto.Message):
         RUNNING = 2
         DONE = 3
 
-    template = proto.Field(proto.STRING, number=1,)
-    version = proto.Field(proto.INT32, number=2,)
-    create_cluster = proto.Field(proto.MESSAGE, number=3, message="ClusterOperation",)
-    graph = proto.Field(proto.MESSAGE, number=4, message="WorkflowGraph",)
-    delete_cluster = proto.Field(proto.MESSAGE, number=5, message="ClusterOperation",)
-    state = proto.Field(proto.ENUM, number=6, enum=State,)
-    cluster_name = proto.Field(proto.STRING, number=7,)
-    parameters = proto.MapField(proto.STRING, proto.STRING, number=8,)
-    start_time = proto.Field(proto.MESSAGE, number=9, message=timestamp_pb2.Timestamp,)
-    end_time = proto.Field(proto.MESSAGE, number=10, message=timestamp_pb2.Timestamp,)
-    cluster_uuid = proto.Field(proto.STRING, number=11,)
-    dag_timeout = proto.Field(proto.MESSAGE, number=12, message=duration_pb2.Duration,)
+    template = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    version = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    create_cluster = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message="ClusterOperation",
+    )
+    graph = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message="WorkflowGraph",
+    )
+    delete_cluster = proto.Field(
+        proto.MESSAGE,
+        number=5,
+        message="ClusterOperation",
+    )
+    state = proto.Field(
+        proto.ENUM,
+        number=6,
+        enum=State,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=7,
+    )
+    parameters = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=8,
+    )
+    start_time = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message=timestamp_pb2.Timestamp,
+    )
+    end_time = proto.Field(
+        proto.MESSAGE,
+        number=10,
+        message=timestamp_pb2.Timestamp,
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=11,
+    )
+    dag_timeout = proto.Field(
+        proto.MESSAGE,
+        number=12,
+        message=duration_pb2.Duration,
+    )
     dag_start_time = proto.Field(
-        proto.MESSAGE, number=13, message=timestamp_pb2.Timestamp,
+        proto.MESSAGE,
+        number=13,
+        message=timestamp_pb2.Timestamp,
     )
     dag_end_time = proto.Field(
-        proto.MESSAGE, number=14, message=timestamp_pb2.Timestamp,
+        proto.MESSAGE,
+        number=14,
+        message=timestamp_pb2.Timestamp,
     )
 
 
@@ -568,9 +736,18 @@ class ClusterOperation(proto.Message):
             Output only. Indicates the operation is done.
     """
 
-    operation_id = proto.Field(proto.STRING, number=1,)
-    error = proto.Field(proto.STRING, number=2,)
-    done = proto.Field(proto.BOOL, number=3,)
+    operation_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    error = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    done = proto.Field(
+        proto.BOOL,
+        number=3,
+    )
 
 
 class WorkflowGraph(proto.Message):
@@ -581,7 +758,11 @@ class WorkflowGraph(proto.Message):
             Output only. The workflow nodes.
     """
 
-    nodes = proto.RepeatedField(proto.MESSAGE, number=1, message="WorkflowNode",)
+    nodes = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message="WorkflowNode",
+    )
 
 
 class WorkflowNode(proto.Message):
@@ -610,11 +791,27 @@ class WorkflowNode(proto.Message):
         COMPLETED = 4
         FAILED = 5
 
-    step_id = proto.Field(proto.STRING, number=1,)
-    prerequisite_step_ids = proto.RepeatedField(proto.STRING, number=2,)
-    job_id = proto.Field(proto.STRING, number=3,)
-    state = proto.Field(proto.ENUM, number=5, enum=NodeState,)
-    error = proto.Field(proto.STRING, number=6,)
+    step_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    prerequisite_step_ids = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    state = proto.Field(
+        proto.ENUM,
+        number=5,
+        enum=NodeState,
+    )
+    error = proto.Field(
+        proto.STRING,
+        number=6,
+    )
 
 
 class CreateWorkflowTemplateRequest(proto.Message):
@@ -638,8 +835,15 @@ class CreateWorkflowTemplateRequest(proto.Message):
             create.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    template = proto.Field(proto.MESSAGE, number=2, message="WorkflowTemplate",)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    template = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="WorkflowTemplate",
+    )
 
 
 class GetWorkflowTemplateRequest(proto.Message):
@@ -665,8 +869,14 @@ class GetWorkflowTemplateRequest(proto.Message):
             If unspecified, retrieves the current version.
     """
 
-    name = proto.Field(proto.STRING, number=1,)
-    version = proto.Field(proto.INT32, number=2,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    version = proto.Field(
+        proto.INT32,
+        number=2,
+    )
 
 
 class InstantiateWorkflowTemplateRequest(proto.Message):
@@ -711,10 +921,23 @@ class InstantiateWorkflowTemplateRequest(proto.Message):
             may not exceed 1000 characters.
     """
 
-    name = proto.Field(proto.STRING, number=1,)
-    version = proto.Field(proto.INT32, number=2,)
-    request_id = proto.Field(proto.STRING, number=5,)
-    parameters = proto.MapField(proto.STRING, proto.STRING, number=6,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    version = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=5,
+    )
+    parameters = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=6,
+    )
 
 
 class InstantiateInlineWorkflowTemplateRequest(proto.Message):
@@ -751,9 +974,19 @@ class InstantiateInlineWorkflowTemplateRequest(proto.Message):
             characters.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    template = proto.Field(proto.MESSAGE, number=2, message="WorkflowTemplate",)
-    request_id = proto.Field(proto.STRING, number=3,)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    template = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="WorkflowTemplate",
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=3,
+    )
 
 
 class UpdateWorkflowTemplateRequest(proto.Message):
@@ -767,7 +1000,11 @@ class UpdateWorkflowTemplateRequest(proto.Message):
             version.
     """
 
-    template = proto.Field(proto.MESSAGE, number=1, message="WorkflowTemplate",)
+    template = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message="WorkflowTemplate",
+    )
 
 
 class ListWorkflowTemplatesRequest(proto.Message):
@@ -795,9 +1032,18 @@ class ListWorkflowTemplatesRequest(proto.Message):
             results.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    page_size = proto.Field(proto.INT32, number=2,)
-    page_token = proto.Field(proto.STRING, number=3,)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    page_size = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    page_token = proto.Field(
+        proto.STRING,
+        number=3,
+    )
 
 
 class ListWorkflowTemplatesResponse(proto.Message):
@@ -819,9 +1065,14 @@ class ListWorkflowTemplatesResponse(proto.Message):
         return self
 
     templates = proto.RepeatedField(
-        proto.MESSAGE, number=1, message="WorkflowTemplate",
+        proto.MESSAGE,
+        number=1,
+        message="WorkflowTemplate",
     )
-    next_page_token = proto.Field(proto.STRING, number=2,)
+    next_page_token = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class DeleteWorkflowTemplateRequest(proto.Message):
@@ -849,8 +1100,14 @@ class DeleteWorkflowTemplateRequest(proto.Message):
             specified version.
     """
 
-    name = proto.Field(proto.STRING, number=1,)
-    version = proto.Field(proto.INT32, number=2,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    version = proto.Field(
+        proto.INT32,
+        number=2,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ import shutil
 import nox
 
 
-BLACK_VERSION = "black==19.10b0"
+BLACK_VERSION = "black==22.3.0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 DEFAULT_PYTHON_VERSION = "3.8"
@@ -57,7 +57,9 @@ def lint(session):
     """
     session.install("flake8", BLACK_VERSION)
     session.run(
-        "black", "--check", *BLACK_PATHS,
+        "black",
+        "--check",
+        *BLACK_PATHS,
     )
     session.run("flake8", "google", "tests")
 
@@ -67,7 +69,8 @@ def blacken(session):
     """Run black. Format code to uniform standard."""
     session.install(BLACK_VERSION)
     session.run(
-        "black", *BLACK_PATHS,
+        "black",
+        *BLACK_PATHS,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,9 @@ setuptools.setup(
     install_requires=dependencies,
     extras_require=extras,
     python_requires=">=3.6",
-    scripts=["scripts/fixup_dataproc_v1_keywords.py",],
+    scripts=[
+        "scripts/fixup_dataproc_v1_keywords.py",
+    ],
     include_package_data=True,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ dependencies = [
     # NOTE: Maintainers, please do not require google-api-core>=2.x.x
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
-    "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "proto-plus >= 1.4.0",
 ]
 extras = {"libcst": "libcst >= 0.2.5"}

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,6 +5,6 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-google-api-core==1.28.0
+google-api-core==1.31.5
 libcst==0.2.5
 proto-plus==1.4.0

--- a/tests/unit/gapic/dataproc_v1/test_autoscaling_policy_service.py
+++ b/tests/unit/gapic/dataproc_v1/test_autoscaling_policy_service.py
@@ -92,7 +92,10 @@ def test__get_default_mtls_endpoint():
 
 @pytest.mark.parametrize(
     "client_class",
-    [AutoscalingPolicyServiceClient, AutoscalingPolicyServiceAsyncClient,],
+    [
+        AutoscalingPolicyServiceClient,
+        AutoscalingPolicyServiceAsyncClient,
+    ],
 )
 def test_autoscaling_policy_service_client_from_service_account_info(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -135,7 +138,10 @@ def test_autoscaling_policy_service_client_service_account_always_use_jwt(
 
 @pytest.mark.parametrize(
     "client_class",
-    [AutoscalingPolicyServiceClient, AutoscalingPolicyServiceAsyncClient,],
+    [
+        AutoscalingPolicyServiceClient,
+        AutoscalingPolicyServiceAsyncClient,
+    ],
 )
 def test_autoscaling_policy_service_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -524,7 +530,9 @@ def test_autoscaling_policy_service_client_client_options_scopes(
     client_class, transport_class, transport_name
 ):
     # Check the case scopes are provided.
-    options = client_options.ClientOptions(scopes=["1", "2"],)
+    options = client_options.ClientOptions(
+        scopes=["1", "2"],
+    )
     with mock.patch.object(transport_class, "__init__") as patched:
         patched.return_value = None
         client = client_class(client_options=options, transport=transport_name)
@@ -665,11 +673,16 @@ def test_autoscaling_policy_service_client_create_channel_credentials_file(
 
 
 @pytest.mark.parametrize(
-    "request_type", [autoscaling_policies.CreateAutoscalingPolicyRequest, dict,]
+    "request_type",
+    [
+        autoscaling_policies.CreateAutoscalingPolicyRequest,
+        dict,
+    ],
 )
 def test_create_autoscaling_policy(request_type, transport: str = "grpc"):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -707,7 +720,8 @@ def test_create_autoscaling_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -726,7 +740,8 @@ async def test_create_autoscaling_policy_async(
     request_type=autoscaling_policies.CreateAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -739,7 +754,10 @@ async def test_create_autoscaling_policy_async(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            autoscaling_policies.AutoscalingPolicy(id="id_value", name="name_value",)
+            autoscaling_policies.AutoscalingPolicy(
+                id="id_value",
+                name="name_value",
+            )
         )
         response = await client.create_autoscaling_policy(request)
 
@@ -784,7 +802,10 @@ def test_create_autoscaling_policy_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -815,7 +836,10 @@ async def test_create_autoscaling_policy_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_create_autoscaling_policy_flattened():
@@ -915,11 +939,16 @@ async def test_create_autoscaling_policy_flattened_error_async():
 
 
 @pytest.mark.parametrize(
-    "request_type", [autoscaling_policies.UpdateAutoscalingPolicyRequest, dict,]
+    "request_type",
+    [
+        autoscaling_policies.UpdateAutoscalingPolicyRequest,
+        dict,
+    ],
 )
 def test_update_autoscaling_policy(request_type, transport: str = "grpc"):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -957,7 +986,8 @@ def test_update_autoscaling_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -976,7 +1006,8 @@ async def test_update_autoscaling_policy_async(
     request_type=autoscaling_policies.UpdateAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -989,7 +1020,10 @@ async def test_update_autoscaling_policy_async(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            autoscaling_policies.AutoscalingPolicy(id="id_value", name="name_value",)
+            autoscaling_policies.AutoscalingPolicy(
+                id="id_value",
+                name="name_value",
+            )
         )
         response = await client.update_autoscaling_policy(request)
 
@@ -1034,7 +1068,10 @@ def test_update_autoscaling_policy_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "policy.name=policy.name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "policy.name=policy.name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1065,7 +1102,10 @@ async def test_update_autoscaling_policy_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "policy.name=policy.name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "policy.name=policy.name/value",
+    ) in kw["metadata"]
 
 
 def test_update_autoscaling_policy_flattened():
@@ -1155,11 +1195,16 @@ async def test_update_autoscaling_policy_flattened_error_async():
 
 
 @pytest.mark.parametrize(
-    "request_type", [autoscaling_policies.GetAutoscalingPolicyRequest, dict,]
+    "request_type",
+    [
+        autoscaling_policies.GetAutoscalingPolicyRequest,
+        dict,
+    ],
 )
 def test_get_autoscaling_policy(request_type, transport: str = "grpc"):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1197,7 +1242,8 @@ def test_get_autoscaling_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1216,7 +1262,8 @@ async def test_get_autoscaling_policy_async(
     request_type=autoscaling_policies.GetAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1229,7 +1276,10 @@ async def test_get_autoscaling_policy_async(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            autoscaling_policies.AutoscalingPolicy(id="id_value", name="name_value",)
+            autoscaling_policies.AutoscalingPolicy(
+                id="id_value",
+                name="name_value",
+            )
         )
         response = await client.get_autoscaling_policy(request)
 
@@ -1274,7 +1324,10 @@ def test_get_autoscaling_policy_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1305,7 +1358,10 @@ async def test_get_autoscaling_policy_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_get_autoscaling_policy_flattened():
@@ -1321,7 +1377,9 @@ def test_get_autoscaling_policy_flattened():
         call.return_value = autoscaling_policies.AutoscalingPolicy()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.get_autoscaling_policy(name="name_value",)
+        client.get_autoscaling_policy(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1341,7 +1399,8 @@ def test_get_autoscaling_policy_flattened_error():
     # fields is an error.
     with pytest.raises(ValueError):
         client.get_autoscaling_policy(
-            autoscaling_policies.GetAutoscalingPolicyRequest(), name="name_value",
+            autoscaling_policies.GetAutoscalingPolicyRequest(),
+            name="name_value",
         )
 
 
@@ -1363,7 +1422,9 @@ async def test_get_autoscaling_policy_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.get_autoscaling_policy(name="name_value",)
+        response = await client.get_autoscaling_policy(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1384,16 +1445,22 @@ async def test_get_autoscaling_policy_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.get_autoscaling_policy(
-            autoscaling_policies.GetAutoscalingPolicyRequest(), name="name_value",
+            autoscaling_policies.GetAutoscalingPolicyRequest(),
+            name="name_value",
         )
 
 
 @pytest.mark.parametrize(
-    "request_type", [autoscaling_policies.ListAutoscalingPoliciesRequest, dict,]
+    "request_type",
+    [
+        autoscaling_policies.ListAutoscalingPoliciesRequest,
+        dict,
+    ],
 )
 def test_list_autoscaling_policies(request_type, transport: str = "grpc"):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1424,7 +1491,8 @@ def test_list_autoscaling_policies_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1443,7 +1511,8 @@ async def test_list_autoscaling_policies_async(
     request_type=autoscaling_policies.ListAutoscalingPoliciesRequest,
 ):
     client = AutoscalingPolicyServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1502,7 +1571,10 @@ def test_list_autoscaling_policies_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1533,7 +1605,10 @@ async def test_list_autoscaling_policies_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_list_autoscaling_policies_flattened():
@@ -1549,7 +1624,9 @@ def test_list_autoscaling_policies_flattened():
         call.return_value = autoscaling_policies.ListAutoscalingPoliciesResponse()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.list_autoscaling_policies(parent="parent_value",)
+        client.list_autoscaling_policies(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1592,7 +1669,9 @@ async def test_list_autoscaling_policies_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.list_autoscaling_policies(parent="parent_value",)
+        response = await client.list_autoscaling_policies(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1620,7 +1699,8 @@ async def test_list_autoscaling_policies_flattened_error_async():
 
 def test_list_autoscaling_policies_pager(transport_name: str = "grpc"):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials, transport=transport_name,
+        credentials=ga_credentials.AnonymousCredentials,
+        transport=transport_name,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1638,10 +1718,13 @@ def test_list_autoscaling_policies_pager(transport_name: str = "grpc"):
                 next_page_token="abc",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[], next_page_token="def",
+                policies=[],
+                next_page_token="def",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[autoscaling_policies.AutoscalingPolicy(),],
+                policies=[
+                    autoscaling_policies.AutoscalingPolicy(),
+                ],
                 next_page_token="ghi",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
@@ -1670,7 +1753,8 @@ def test_list_autoscaling_policies_pager(transport_name: str = "grpc"):
 
 def test_list_autoscaling_policies_pages(transport_name: str = "grpc"):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials, transport=transport_name,
+        credentials=ga_credentials.AnonymousCredentials,
+        transport=transport_name,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1688,10 +1772,13 @@ def test_list_autoscaling_policies_pages(transport_name: str = "grpc"):
                 next_page_token="abc",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[], next_page_token="def",
+                policies=[],
+                next_page_token="def",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[autoscaling_policies.AutoscalingPolicy(),],
+                policies=[
+                    autoscaling_policies.AutoscalingPolicy(),
+                ],
                 next_page_token="ghi",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
@@ -1730,10 +1817,13 @@ async def test_list_autoscaling_policies_async_pager():
                 next_page_token="abc",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[], next_page_token="def",
+                policies=[],
+                next_page_token="def",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[autoscaling_policies.AutoscalingPolicy(),],
+                policies=[
+                    autoscaling_policies.AutoscalingPolicy(),
+                ],
                 next_page_token="ghi",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
@@ -1744,7 +1834,9 @@ async def test_list_autoscaling_policies_async_pager():
             ),
             RuntimeError,
         )
-        async_pager = await client.list_autoscaling_policies(request={},)
+        async_pager = await client.list_autoscaling_policies(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -1779,10 +1871,13 @@ async def test_list_autoscaling_policies_async_pages():
                 next_page_token="abc",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[], next_page_token="def",
+                policies=[],
+                next_page_token="def",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[autoscaling_policies.AutoscalingPolicy(),],
+                policies=[
+                    autoscaling_policies.AutoscalingPolicy(),
+                ],
                 next_page_token="ghi",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
@@ -1801,11 +1896,16 @@ async def test_list_autoscaling_policies_async_pages():
 
 
 @pytest.mark.parametrize(
-    "request_type", [autoscaling_policies.DeleteAutoscalingPolicyRequest, dict,]
+    "request_type",
+    [
+        autoscaling_policies.DeleteAutoscalingPolicyRequest,
+        dict,
+    ],
 )
 def test_delete_autoscaling_policy(request_type, transport: str = "grpc"):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1833,7 +1933,8 @@ def test_delete_autoscaling_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1852,7 +1953,8 @@ async def test_delete_autoscaling_policy_async(
     request_type=autoscaling_policies.DeleteAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1906,7 +2008,10 @@ def test_delete_autoscaling_policy_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1935,7 +2040,10 @@ async def test_delete_autoscaling_policy_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_delete_autoscaling_policy_flattened():
@@ -1951,7 +2059,9 @@ def test_delete_autoscaling_policy_flattened():
         call.return_value = None
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.delete_autoscaling_policy(name="name_value",)
+        client.delete_autoscaling_policy(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1971,7 +2081,8 @@ def test_delete_autoscaling_policy_flattened_error():
     # fields is an error.
     with pytest.raises(ValueError):
         client.delete_autoscaling_policy(
-            autoscaling_policies.DeleteAutoscalingPolicyRequest(), name="name_value",
+            autoscaling_policies.DeleteAutoscalingPolicyRequest(),
+            name="name_value",
         )
 
 
@@ -1991,7 +2102,9 @@ async def test_delete_autoscaling_policy_flattened_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.delete_autoscaling_policy(name="name_value",)
+        response = await client.delete_autoscaling_policy(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2012,7 +2125,8 @@ async def test_delete_autoscaling_policy_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.delete_autoscaling_policy(
-            autoscaling_policies.DeleteAutoscalingPolicyRequest(), name="name_value",
+            autoscaling_policies.DeleteAutoscalingPolicyRequest(),
+            name="name_value",
         )
 
 
@@ -2023,7 +2137,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = AutoscalingPolicyServiceClient(
-            credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
@@ -2044,7 +2159,8 @@ def test_credentials_transport_error():
     options.api_key = "api_key"
     with pytest.raises(ValueError):
         client = AutoscalingPolicyServiceClient(
-            client_options=options, transport=transport,
+            client_options=options,
+            transport=transport,
         )
 
     # It is an error to provide an api_key and a credential.
@@ -2061,7 +2177,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = AutoscalingPolicyServiceClient(
-            client_options={"scopes": ["1", "2"]}, transport=transport,
+            client_options={"scopes": ["1", "2"]},
+            transport=transport,
         )
 
 
@@ -2110,7 +2227,8 @@ def test_transport_grpc_default():
         credentials=ga_credentials.AnonymousCredentials(),
     )
     assert isinstance(
-        client.transport, transports.AutoscalingPolicyServiceGrpcTransport,
+        client.transport,
+        transports.AutoscalingPolicyServiceGrpcTransport,
     )
 
 
@@ -2160,7 +2278,8 @@ def test_autoscaling_policy_service_base_transport_with_credentials_file():
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.AutoscalingPolicyServiceTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -2322,7 +2441,8 @@ def test_autoscaling_policy_service_grpc_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.AutoscalingPolicyServiceGrpcTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2334,7 +2454,8 @@ def test_autoscaling_policy_service_grpc_asyncio_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.AutoscalingPolicyServiceGrpcAsyncIOTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2446,7 +2567,9 @@ def test_autoscaling_policy_path():
     location = "clam"
     autoscaling_policy = "whelk"
     expected = "projects/{project}/locations/{location}/autoscalingPolicies/{autoscaling_policy}".format(
-        project=project, location=location, autoscaling_policy=autoscaling_policy,
+        project=project,
+        location=location,
+        autoscaling_policy=autoscaling_policy,
     )
     actual = AutoscalingPolicyServiceClient.autoscaling_policy_path(
         project, location, autoscaling_policy
@@ -2489,7 +2612,9 @@ def test_parse_common_billing_account_path():
 
 def test_common_folder_path():
     folder = "winkle"
-    expected = "folders/{folder}".format(folder=folder,)
+    expected = "folders/{folder}".format(
+        folder=folder,
+    )
     actual = AutoscalingPolicyServiceClient.common_folder_path(folder)
     assert expected == actual
 
@@ -2507,7 +2632,9 @@ def test_parse_common_folder_path():
 
 def test_common_organization_path():
     organization = "scallop"
-    expected = "organizations/{organization}".format(organization=organization,)
+    expected = "organizations/{organization}".format(
+        organization=organization,
+    )
     actual = AutoscalingPolicyServiceClient.common_organization_path(organization)
     assert expected == actual
 
@@ -2525,7 +2652,9 @@ def test_parse_common_organization_path():
 
 def test_common_project_path():
     project = "squid"
-    expected = "projects/{project}".format(project=project,)
+    expected = "projects/{project}".format(
+        project=project,
+    )
     actual = AutoscalingPolicyServiceClient.common_project_path(project)
     assert expected == actual
 
@@ -2545,7 +2674,8 @@ def test_common_location_path():
     project = "whelk"
     location = "octopus"
     expected = "projects/{project}/locations/{location}".format(
-        project=project, location=location,
+        project=project,
+        location=location,
     )
     actual = AutoscalingPolicyServiceClient.common_location_path(project, location)
     assert expected == actual
@@ -2570,7 +2700,8 @@ def test_client_with_default_client_info():
         transports.AutoscalingPolicyServiceTransport, "_prep_wrapped_messages"
     ) as prep:
         client = AutoscalingPolicyServiceClient(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -2579,7 +2710,8 @@ def test_client_with_default_client_info():
     ) as prep:
         transport_class = AutoscalingPolicyServiceClient.get_transport_class()
         transport = transport_class(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -2587,7 +2719,8 @@ def test_client_with_default_client_info():
 @pytest.mark.asyncio
 async def test_transport_close_async():
     client = AutoscalingPolicyServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     with mock.patch.object(
         type(getattr(client.transport, "grpc_channel")), "close"

--- a/tests/unit/gapic/dataproc_v1/test_batch_controller.py
+++ b/tests/unit/gapic/dataproc_v1/test_batch_controller.py
@@ -95,7 +95,11 @@ def test__get_default_mtls_endpoint():
 
 
 @pytest.mark.parametrize(
-    "client_class", [BatchControllerClient, BatchControllerAsyncClient,]
+    "client_class",
+    [
+        BatchControllerClient,
+        BatchControllerAsyncClient,
+    ],
 )
 def test_batch_controller_client_from_service_account_info(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -137,7 +141,11 @@ def test_batch_controller_client_service_account_always_use_jwt(
 
 
 @pytest.mark.parametrize(
-    "client_class", [BatchControllerClient, BatchControllerAsyncClient,]
+    "client_class",
+    [
+        BatchControllerClient,
+        BatchControllerAsyncClient,
+    ],
 )
 def test_batch_controller_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -511,7 +519,9 @@ def test_batch_controller_client_client_options_scopes(
     client_class, transport_class, transport_name
 ):
     # Check the case scopes are provided.
-    options = client_options.ClientOptions(scopes=["1", "2"],)
+    options = client_options.ClientOptions(
+        scopes=["1", "2"],
+    )
     with mock.patch.object(transport_class, "__init__") as patched:
         patched.return_value = None
         client = client_class(client_options=options, transport=transport_name)
@@ -651,10 +661,17 @@ def test_batch_controller_client_create_channel_credentials_file(
         )
 
 
-@pytest.mark.parametrize("request_type", [batches.CreateBatchRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        batches.CreateBatchRequest,
+        dict,
+    ],
+)
 def test_create_batch(request_type, transport: str = "grpc"):
     client = BatchControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -680,7 +697,8 @@ def test_create_batch_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BatchControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -696,7 +714,8 @@ async def test_create_batch_async(
     transport: str = "grpc_asyncio", request_type=batches.CreateBatchRequest
 ):
     client = BatchControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -726,7 +745,9 @@ async def test_create_batch_async_from_dict():
 
 
 def test_create_batch_field_headers():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -746,7 +767,10 @@ def test_create_batch_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -775,11 +799,16 @@ async def test_create_batch_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_create_batch_flattened():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_batch), "__call__") as call:
@@ -809,7 +838,9 @@ def test_create_batch_flattened():
 
 
 def test_create_batch_flattened_error():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -876,10 +907,17 @@ async def test_create_batch_flattened_error_async():
         )
 
 
-@pytest.mark.parametrize("request_type", [batches.GetBatchRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        batches.GetBatchRequest,
+        dict,
+    ],
+)
 def test_get_batch(request_type, transport: str = "grpc"):
     client = BatchControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -921,7 +959,8 @@ def test_get_batch_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BatchControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -937,7 +976,8 @@ async def test_get_batch_async(
     transport: str = "grpc_asyncio", request_type=batches.GetBatchRequest
 ):
     client = BatchControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -980,7 +1020,9 @@ async def test_get_batch_async_from_dict():
 
 
 def test_get_batch_field_headers():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -1000,7 +1042,10 @@ def test_get_batch_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1027,11 +1072,16 @@ async def test_get_batch_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_get_batch_flattened():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_batch), "__call__") as call:
@@ -1039,7 +1089,9 @@ def test_get_batch_flattened():
         call.return_value = batches.Batch()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.get_batch(name="name_value",)
+        client.get_batch(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1051,13 +1103,16 @@ def test_get_batch_flattened():
 
 
 def test_get_batch_flattened_error():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.get_batch(
-            batches.GetBatchRequest(), name="name_value",
+            batches.GetBatchRequest(),
+            name="name_value",
         )
 
 
@@ -1075,7 +1130,9 @@ async def test_get_batch_flattened_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(batches.Batch())
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.get_batch(name="name_value",)
+        response = await client.get_batch(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1096,14 +1153,22 @@ async def test_get_batch_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.get_batch(
-            batches.GetBatchRequest(), name="name_value",
+            batches.GetBatchRequest(),
+            name="name_value",
         )
 
 
-@pytest.mark.parametrize("request_type", [batches.ListBatchesRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        batches.ListBatchesRequest,
+        dict,
+    ],
+)
 def test_list_batches(request_type, transport: str = "grpc"):
     client = BatchControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1132,7 +1197,8 @@ def test_list_batches_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BatchControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1148,7 +1214,8 @@ async def test_list_batches_async(
     transport: str = "grpc_asyncio", request_type=batches.ListBatchesRequest
 ):
     client = BatchControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1159,7 +1226,9 @@ async def test_list_batches_async(
     with mock.patch.object(type(client.transport.list_batches), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            batches.ListBatchesResponse(next_page_token="next_page_token_value",)
+            batches.ListBatchesResponse(
+                next_page_token="next_page_token_value",
+            )
         )
         response = await client.list_batches(request)
 
@@ -1179,7 +1248,9 @@ async def test_list_batches_async_from_dict():
 
 
 def test_list_batches_field_headers():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -1199,7 +1270,10 @@ def test_list_batches_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1228,11 +1302,16 @@ async def test_list_batches_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_list_batches_flattened():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_batches), "__call__") as call:
@@ -1240,7 +1319,9 @@ def test_list_batches_flattened():
         call.return_value = batches.ListBatchesResponse()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.list_batches(parent="parent_value",)
+        client.list_batches(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1252,13 +1333,16 @@ def test_list_batches_flattened():
 
 
 def test_list_batches_flattened_error():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.list_batches(
-            batches.ListBatchesRequest(), parent="parent_value",
+            batches.ListBatchesRequest(),
+            parent="parent_value",
         )
 
 
@@ -1278,7 +1362,9 @@ async def test_list_batches_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.list_batches(parent="parent_value",)
+        response = await client.list_batches(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1299,13 +1385,15 @@ async def test_list_batches_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.list_batches(
-            batches.ListBatchesRequest(), parent="parent_value",
+            batches.ListBatchesRequest(),
+            parent="parent_value",
         )
 
 
 def test_list_batches_pager(transport_name: str = "grpc"):
     client = BatchControllerClient(
-        credentials=ga_credentials.AnonymousCredentials, transport=transport_name,
+        credentials=ga_credentials.AnonymousCredentials,
+        transport=transport_name,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1313,14 +1401,29 @@ def test_list_batches_pager(transport_name: str = "grpc"):
         # Set the response to a series of pages.
         call.side_effect = (
             batches.ListBatchesResponse(
-                batches=[batches.Batch(), batches.Batch(), batches.Batch(),],
+                batches=[
+                    batches.Batch(),
+                    batches.Batch(),
+                    batches.Batch(),
+                ],
                 next_page_token="abc",
             ),
-            batches.ListBatchesResponse(batches=[], next_page_token="def",),
             batches.ListBatchesResponse(
-                batches=[batches.Batch(),], next_page_token="ghi",
+                batches=[],
+                next_page_token="def",
             ),
-            batches.ListBatchesResponse(batches=[batches.Batch(), batches.Batch(),],),
+            batches.ListBatchesResponse(
+                batches=[
+                    batches.Batch(),
+                ],
+                next_page_token="ghi",
+            ),
+            batches.ListBatchesResponse(
+                batches=[
+                    batches.Batch(),
+                    batches.Batch(),
+                ],
+            ),
             RuntimeError,
         )
 
@@ -1339,7 +1442,8 @@ def test_list_batches_pager(transport_name: str = "grpc"):
 
 def test_list_batches_pages(transport_name: str = "grpc"):
     client = BatchControllerClient(
-        credentials=ga_credentials.AnonymousCredentials, transport=transport_name,
+        credentials=ga_credentials.AnonymousCredentials,
+        transport=transport_name,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1347,14 +1451,29 @@ def test_list_batches_pages(transport_name: str = "grpc"):
         # Set the response to a series of pages.
         call.side_effect = (
             batches.ListBatchesResponse(
-                batches=[batches.Batch(), batches.Batch(), batches.Batch(),],
+                batches=[
+                    batches.Batch(),
+                    batches.Batch(),
+                    batches.Batch(),
+                ],
                 next_page_token="abc",
             ),
-            batches.ListBatchesResponse(batches=[], next_page_token="def",),
             batches.ListBatchesResponse(
-                batches=[batches.Batch(),], next_page_token="ghi",
+                batches=[],
+                next_page_token="def",
             ),
-            batches.ListBatchesResponse(batches=[batches.Batch(), batches.Batch(),],),
+            batches.ListBatchesResponse(
+                batches=[
+                    batches.Batch(),
+                ],
+                next_page_token="ghi",
+            ),
+            batches.ListBatchesResponse(
+                batches=[
+                    batches.Batch(),
+                    batches.Batch(),
+                ],
+            ),
             RuntimeError,
         )
         pages = list(client.list_batches(request={}).pages)
@@ -1375,17 +1494,34 @@ async def test_list_batches_async_pager():
         # Set the response to a series of pages.
         call.side_effect = (
             batches.ListBatchesResponse(
-                batches=[batches.Batch(), batches.Batch(), batches.Batch(),],
+                batches=[
+                    batches.Batch(),
+                    batches.Batch(),
+                    batches.Batch(),
+                ],
                 next_page_token="abc",
             ),
-            batches.ListBatchesResponse(batches=[], next_page_token="def",),
             batches.ListBatchesResponse(
-                batches=[batches.Batch(),], next_page_token="ghi",
+                batches=[],
+                next_page_token="def",
             ),
-            batches.ListBatchesResponse(batches=[batches.Batch(), batches.Batch(),],),
+            batches.ListBatchesResponse(
+                batches=[
+                    batches.Batch(),
+                ],
+                next_page_token="ghi",
+            ),
+            batches.ListBatchesResponse(
+                batches=[
+                    batches.Batch(),
+                    batches.Batch(),
+                ],
+            ),
             RuntimeError,
         )
-        async_pager = await client.list_batches(request={},)
+        async_pager = await client.list_batches(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -1408,14 +1544,29 @@ async def test_list_batches_async_pages():
         # Set the response to a series of pages.
         call.side_effect = (
             batches.ListBatchesResponse(
-                batches=[batches.Batch(), batches.Batch(), batches.Batch(),],
+                batches=[
+                    batches.Batch(),
+                    batches.Batch(),
+                    batches.Batch(),
+                ],
                 next_page_token="abc",
             ),
-            batches.ListBatchesResponse(batches=[], next_page_token="def",),
             batches.ListBatchesResponse(
-                batches=[batches.Batch(),], next_page_token="ghi",
+                batches=[],
+                next_page_token="def",
             ),
-            batches.ListBatchesResponse(batches=[batches.Batch(), batches.Batch(),],),
+            batches.ListBatchesResponse(
+                batches=[
+                    batches.Batch(),
+                ],
+                next_page_token="ghi",
+            ),
+            batches.ListBatchesResponse(
+                batches=[
+                    batches.Batch(),
+                    batches.Batch(),
+                ],
+            ),
             RuntimeError,
         )
         pages = []
@@ -1425,10 +1576,17 @@ async def test_list_batches_async_pages():
             assert page_.raw_page.next_page_token == token
 
 
-@pytest.mark.parametrize("request_type", [batches.DeleteBatchRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        batches.DeleteBatchRequest,
+        dict,
+    ],
+)
 def test_delete_batch(request_type, transport: str = "grpc"):
     client = BatchControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1454,7 +1612,8 @@ def test_delete_batch_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = BatchControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1470,7 +1629,8 @@ async def test_delete_batch_async(
     transport: str = "grpc_asyncio", request_type=batches.DeleteBatchRequest
 ):
     client = BatchControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1498,7 +1658,9 @@ async def test_delete_batch_async_from_dict():
 
 
 def test_delete_batch_field_headers():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -1518,7 +1680,10 @@ def test_delete_batch_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1545,11 +1710,16 @@ async def test_delete_batch_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_delete_batch_flattened():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_batch), "__call__") as call:
@@ -1557,7 +1727,9 @@ def test_delete_batch_flattened():
         call.return_value = None
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.delete_batch(name="name_value",)
+        client.delete_batch(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1569,13 +1741,16 @@ def test_delete_batch_flattened():
 
 
 def test_delete_batch_flattened_error():
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.delete_batch(
-            batches.DeleteBatchRequest(), name="name_value",
+            batches.DeleteBatchRequest(),
+            name="name_value",
         )
 
 
@@ -1593,7 +1768,9 @@ async def test_delete_batch_flattened_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.delete_batch(name="name_value",)
+        response = await client.delete_batch(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1614,7 +1791,8 @@ async def test_delete_batch_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.delete_batch(
-            batches.DeleteBatchRequest(), name="name_value",
+            batches.DeleteBatchRequest(),
+            name="name_value",
         )
 
 
@@ -1625,7 +1803,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = BatchControllerClient(
-            credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
@@ -1645,7 +1824,10 @@ def test_credentials_transport_error():
     options = client_options.ClientOptions()
     options.api_key = "api_key"
     with pytest.raises(ValueError):
-        client = BatchControllerClient(client_options=options, transport=transport,)
+        client = BatchControllerClient(
+            client_options=options,
+            transport=transport,
+        )
 
     # It is an error to provide an api_key and a credential.
     options = mock.Mock()
@@ -1661,7 +1843,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = BatchControllerClient(
-            client_options={"scopes": ["1", "2"]}, transport=transport,
+            client_options={"scopes": ["1", "2"]},
+            transport=transport,
         )
 
 
@@ -1706,8 +1889,13 @@ def test_transport_adc(transport_class):
 
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
-    client = BatchControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
-    assert isinstance(client.transport, transports.BatchControllerGrpcTransport,)
+    client = BatchControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    assert isinstance(
+        client.transport,
+        transports.BatchControllerGrpcTransport,
+    )
 
 
 def test_batch_controller_base_transport_error():
@@ -1760,7 +1948,8 @@ def test_batch_controller_base_transport_with_credentials_file():
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.BatchControllerTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -1918,7 +2107,8 @@ def test_batch_controller_grpc_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.BatchControllerGrpcTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -1930,7 +2120,8 @@ def test_batch_controller_grpc_asyncio_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.BatchControllerGrpcAsyncIOTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2039,12 +2230,16 @@ def test_batch_controller_transport_channel_mtls_with_adc(transport_class):
 
 def test_batch_controller_grpc_lro_client():
     client = BatchControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2052,12 +2247,16 @@ def test_batch_controller_grpc_lro_client():
 
 def test_batch_controller_grpc_lro_async_client():
     client = BatchControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsAsyncClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsAsyncClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2068,7 +2267,9 @@ def test_batch_path():
     location = "clam"
     batch = "whelk"
     expected = "projects/{project}/locations/{location}/batches/{batch}".format(
-        project=project, location=location, batch=batch,
+        project=project,
+        location=location,
+        batch=batch,
     )
     actual = BatchControllerClient.batch_path(project, location, batch)
     assert expected == actual
@@ -2109,7 +2310,9 @@ def test_parse_common_billing_account_path():
 
 def test_common_folder_path():
     folder = "winkle"
-    expected = "folders/{folder}".format(folder=folder,)
+    expected = "folders/{folder}".format(
+        folder=folder,
+    )
     actual = BatchControllerClient.common_folder_path(folder)
     assert expected == actual
 
@@ -2127,7 +2330,9 @@ def test_parse_common_folder_path():
 
 def test_common_organization_path():
     organization = "scallop"
-    expected = "organizations/{organization}".format(organization=organization,)
+    expected = "organizations/{organization}".format(
+        organization=organization,
+    )
     actual = BatchControllerClient.common_organization_path(organization)
     assert expected == actual
 
@@ -2145,7 +2350,9 @@ def test_parse_common_organization_path():
 
 def test_common_project_path():
     project = "squid"
-    expected = "projects/{project}".format(project=project,)
+    expected = "projects/{project}".format(
+        project=project,
+    )
     actual = BatchControllerClient.common_project_path(project)
     assert expected == actual
 
@@ -2165,7 +2372,8 @@ def test_common_location_path():
     project = "whelk"
     location = "octopus"
     expected = "projects/{project}/locations/{location}".format(
-        project=project, location=location,
+        project=project,
+        location=location,
     )
     actual = BatchControllerClient.common_location_path(project, location)
     assert expected == actual
@@ -2190,7 +2398,8 @@ def test_client_with_default_client_info():
         transports.BatchControllerTransport, "_prep_wrapped_messages"
     ) as prep:
         client = BatchControllerClient(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -2199,7 +2408,8 @@ def test_client_with_default_client_info():
     ) as prep:
         transport_class = BatchControllerClient.get_transport_class()
         transport = transport_class(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -2207,7 +2417,8 @@ def test_client_with_default_client_info():
 @pytest.mark.asyncio
 async def test_transport_close_async():
     client = BatchControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     with mock.patch.object(
         type(getattr(client.transport, "grpc_channel")), "close"

--- a/tests/unit/gapic/dataproc_v1/test_cluster_controller.py
+++ b/tests/unit/gapic/dataproc_v1/test_cluster_controller.py
@@ -98,7 +98,11 @@ def test__get_default_mtls_endpoint():
 
 
 @pytest.mark.parametrize(
-    "client_class", [ClusterControllerClient, ClusterControllerAsyncClient,]
+    "client_class",
+    [
+        ClusterControllerClient,
+        ClusterControllerAsyncClient,
+    ],
 )
 def test_cluster_controller_client_from_service_account_info(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -140,7 +144,11 @@ def test_cluster_controller_client_service_account_always_use_jwt(
 
 
 @pytest.mark.parametrize(
-    "client_class", [ClusterControllerClient, ClusterControllerAsyncClient,]
+    "client_class",
+    [
+        ClusterControllerClient,
+        ClusterControllerAsyncClient,
+    ],
 )
 def test_cluster_controller_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -514,7 +522,9 @@ def test_cluster_controller_client_client_options_scopes(
     client_class, transport_class, transport_name
 ):
     # Check the case scopes are provided.
-    options = client_options.ClientOptions(scopes=["1", "2"],)
+    options = client_options.ClientOptions(
+        scopes=["1", "2"],
+    )
     with mock.patch.object(transport_class, "__init__") as patched:
         patched.return_value = None
         client = client_class(client_options=options, transport=transport_name)
@@ -654,10 +664,17 @@ def test_cluster_controller_client_create_channel_credentials_file(
         )
 
 
-@pytest.mark.parametrize("request_type", [clusters.CreateClusterRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        clusters.CreateClusterRequest,
+        dict,
+    ],
+)
 def test_create_cluster(request_type, transport: str = "grpc"):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -683,7 +700,8 @@ def test_create_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -699,7 +717,8 @@ async def test_create_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.CreateClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -729,7 +748,9 @@ async def test_create_cluster_async_from_dict():
 
 
 def test_create_cluster_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_cluster), "__call__") as call:
@@ -759,7 +780,9 @@ def test_create_cluster_flattened():
 
 
 def test_create_cluster_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -826,10 +849,17 @@ async def test_create_cluster_flattened_error_async():
         )
 
 
-@pytest.mark.parametrize("request_type", [clusters.UpdateClusterRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        clusters.UpdateClusterRequest,
+        dict,
+    ],
+)
 def test_update_cluster(request_type, transport: str = "grpc"):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -855,7 +885,8 @@ def test_update_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -871,7 +902,8 @@ async def test_update_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.UpdateClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -901,7 +933,9 @@ async def test_update_cluster_async_from_dict():
 
 
 def test_update_cluster_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_cluster), "__call__") as call:
@@ -939,7 +973,9 @@ def test_update_cluster_flattened():
 
 
 def test_update_cluster_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1018,10 +1054,17 @@ async def test_update_cluster_flattened_error_async():
         )
 
 
-@pytest.mark.parametrize("request_type", [clusters.StopClusterRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        clusters.StopClusterRequest,
+        dict,
+    ],
+)
 def test_stop_cluster(request_type, transport: str = "grpc"):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1047,7 +1090,8 @@ def test_stop_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1063,7 +1107,8 @@ async def test_stop_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.StopClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1092,10 +1137,17 @@ async def test_stop_cluster_async_from_dict():
     await test_stop_cluster_async(request_type=dict)
 
 
-@pytest.mark.parametrize("request_type", [clusters.StartClusterRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        clusters.StartClusterRequest,
+        dict,
+    ],
+)
 def test_start_cluster(request_type, transport: str = "grpc"):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1121,7 +1173,8 @@ def test_start_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1137,7 +1190,8 @@ async def test_start_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.StartClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1166,10 +1220,17 @@ async def test_start_cluster_async_from_dict():
     await test_start_cluster_async(request_type=dict)
 
 
-@pytest.mark.parametrize("request_type", [clusters.DeleteClusterRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        clusters.DeleteClusterRequest,
+        dict,
+    ],
+)
 def test_delete_cluster(request_type, transport: str = "grpc"):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1195,7 +1256,8 @@ def test_delete_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1211,7 +1273,8 @@ async def test_delete_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.DeleteClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1241,7 +1304,9 @@ async def test_delete_cluster_async_from_dict():
 
 
 def test_delete_cluster_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_cluster), "__call__") as call:
@@ -1271,7 +1336,9 @@ def test_delete_cluster_flattened():
 
 
 def test_delete_cluster_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1338,10 +1405,17 @@ async def test_delete_cluster_flattened_error_async():
         )
 
 
-@pytest.mark.parametrize("request_type", [clusters.GetClusterRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        clusters.GetClusterRequest,
+        dict,
+    ],
+)
 def test_get_cluster(request_type, transport: str = "grpc"):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1374,7 +1448,8 @@ def test_get_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1390,7 +1465,8 @@ async def test_get_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.GetClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1427,7 +1503,9 @@ async def test_get_cluster_async_from_dict():
 
 
 def test_get_cluster_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_cluster), "__call__") as call:
@@ -1457,7 +1535,9 @@ def test_get_cluster_flattened():
 
 
 def test_get_cluster_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1522,10 +1602,17 @@ async def test_get_cluster_flattened_error_async():
         )
 
 
-@pytest.mark.parametrize("request_type", [clusters.ListClustersRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        clusters.ListClustersRequest,
+        dict,
+    ],
+)
 def test_list_clusters(request_type, transport: str = "grpc"):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1554,7 +1641,8 @@ def test_list_clusters_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1570,7 +1658,8 @@ async def test_list_clusters_async(
     transport: str = "grpc_asyncio", request_type=clusters.ListClustersRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1581,7 +1670,9 @@ async def test_list_clusters_async(
     with mock.patch.object(type(client.transport.list_clusters), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            clusters.ListClustersResponse(next_page_token="next_page_token_value",)
+            clusters.ListClustersResponse(
+                next_page_token="next_page_token_value",
+            )
         )
         response = await client.list_clusters(request)
 
@@ -1601,7 +1692,9 @@ async def test_list_clusters_async_from_dict():
 
 
 def test_list_clusters_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_clusters), "__call__") as call:
@@ -1610,7 +1703,9 @@ def test_list_clusters_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.list_clusters(
-            project_id="project_id_value", region="region_value", filter="filter_value",
+            project_id="project_id_value",
+            region="region_value",
+            filter="filter_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1629,7 +1724,9 @@ def test_list_clusters_flattened():
 
 
 def test_list_clusters_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1659,7 +1756,9 @@ async def test_list_clusters_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.list_clusters(
-            project_id="project_id_value", region="region_value", filter="filter_value",
+            project_id="project_id_value",
+            region="region_value",
+            filter="filter_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1696,7 +1795,8 @@ async def test_list_clusters_flattened_error_async():
 
 def test_list_clusters_pager(transport_name: str = "grpc"):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials, transport=transport_name,
+        credentials=ga_credentials.AnonymousCredentials,
+        transport=transport_name,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1704,15 +1804,28 @@ def test_list_clusters_pager(transport_name: str = "grpc"):
         # Set the response to a series of pages.
         call.side_effect = (
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
                 next_page_token="abc",
             ),
-            clusters.ListClustersResponse(clusters=[], next_page_token="def",),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(),], next_page_token="ghi",
+                clusters=[],
+                next_page_token="def",
             ),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                ],
+                next_page_token="ghi",
+            ),
+            clusters.ListClustersResponse(
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
             ),
             RuntimeError,
         )
@@ -1729,7 +1842,8 @@ def test_list_clusters_pager(transport_name: str = "grpc"):
 
 def test_list_clusters_pages(transport_name: str = "grpc"):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials, transport=transport_name,
+        credentials=ga_credentials.AnonymousCredentials,
+        transport=transport_name,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1737,15 +1851,28 @@ def test_list_clusters_pages(transport_name: str = "grpc"):
         # Set the response to a series of pages.
         call.side_effect = (
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
                 next_page_token="abc",
             ),
-            clusters.ListClustersResponse(clusters=[], next_page_token="def",),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(),], next_page_token="ghi",
+                clusters=[],
+                next_page_token="def",
             ),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                ],
+                next_page_token="ghi",
+            ),
+            clusters.ListClustersResponse(
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
             ),
             RuntimeError,
         )
@@ -1767,19 +1894,34 @@ async def test_list_clusters_async_pager():
         # Set the response to a series of pages.
         call.side_effect = (
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
                 next_page_token="abc",
             ),
-            clusters.ListClustersResponse(clusters=[], next_page_token="def",),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(),], next_page_token="ghi",
+                clusters=[],
+                next_page_token="def",
             ),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                ],
+                next_page_token="ghi",
+            ),
+            clusters.ListClustersResponse(
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
             ),
             RuntimeError,
         )
-        async_pager = await client.list_clusters(request={},)
+        async_pager = await client.list_clusters(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -1802,15 +1944,28 @@ async def test_list_clusters_async_pages():
         # Set the response to a series of pages.
         call.side_effect = (
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
                 next_page_token="abc",
             ),
-            clusters.ListClustersResponse(clusters=[], next_page_token="def",),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(),], next_page_token="ghi",
+                clusters=[],
+                next_page_token="def",
             ),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                ],
+                next_page_token="ghi",
+            ),
+            clusters.ListClustersResponse(
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
             ),
             RuntimeError,
         )
@@ -1821,10 +1976,17 @@ async def test_list_clusters_async_pages():
             assert page_.raw_page.next_page_token == token
 
 
-@pytest.mark.parametrize("request_type", [clusters.DiagnoseClusterRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        clusters.DiagnoseClusterRequest,
+        dict,
+    ],
+)
 def test_diagnose_cluster(request_type, transport: str = "grpc"):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1850,7 +2012,8 @@ def test_diagnose_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1866,7 +2029,8 @@ async def test_diagnose_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.DiagnoseClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1896,7 +2060,9 @@ async def test_diagnose_cluster_async_from_dict():
 
 
 def test_diagnose_cluster_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.diagnose_cluster), "__call__") as call:
@@ -1926,7 +2092,9 @@ def test_diagnose_cluster_flattened():
 
 
 def test_diagnose_cluster_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -2000,7 +2168,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = ClusterControllerClient(
-            credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
@@ -2020,7 +2189,10 @@ def test_credentials_transport_error():
     options = client_options.ClientOptions()
     options.api_key = "api_key"
     with pytest.raises(ValueError):
-        client = ClusterControllerClient(client_options=options, transport=transport,)
+        client = ClusterControllerClient(
+            client_options=options,
+            transport=transport,
+        )
 
     # It is an error to provide an api_key and a credential.
     options = mock.Mock()
@@ -2036,7 +2208,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = ClusterControllerClient(
-            client_options={"scopes": ["1", "2"]}, transport=transport,
+            client_options={"scopes": ["1", "2"]},
+            transport=transport,
         )
 
 
@@ -2081,8 +2254,13 @@ def test_transport_adc(transport_class):
 
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
-    assert isinstance(client.transport, transports.ClusterControllerGrpcTransport,)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    assert isinstance(
+        client.transport,
+        transports.ClusterControllerGrpcTransport,
+    )
 
 
 def test_cluster_controller_base_transport_error():
@@ -2139,7 +2317,8 @@ def test_cluster_controller_base_transport_with_credentials_file():
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.ClusterControllerTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -2297,7 +2476,8 @@ def test_cluster_controller_grpc_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.ClusterControllerGrpcTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2309,7 +2489,8 @@ def test_cluster_controller_grpc_asyncio_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.ClusterControllerGrpcAsyncIOTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2418,12 +2599,16 @@ def test_cluster_controller_transport_channel_mtls_with_adc(transport_class):
 
 def test_cluster_controller_grpc_lro_client():
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2431,12 +2616,16 @@ def test_cluster_controller_grpc_lro_client():
 
 def test_cluster_controller_grpc_lro_async_client():
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsAsyncClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsAsyncClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2447,7 +2636,9 @@ def test_cluster_path():
     location = "clam"
     cluster = "whelk"
     expected = "projects/{project}/locations/{location}/clusters/{cluster}".format(
-        project=project, location=location, cluster=cluster,
+        project=project,
+        location=location,
+        cluster=cluster,
     )
     actual = ClusterControllerClient.cluster_path(project, location, cluster)
     assert expected == actual
@@ -2471,7 +2662,9 @@ def test_service_path():
     location = "mussel"
     service = "winkle"
     expected = "projects/{project}/locations/{location}/services/{service}".format(
-        project=project, location=location, service=service,
+        project=project,
+        location=location,
+        service=service,
     )
     actual = ClusterControllerClient.service_path(project, location, service)
     assert expected == actual
@@ -2512,7 +2705,9 @@ def test_parse_common_billing_account_path():
 
 def test_common_folder_path():
     folder = "whelk"
-    expected = "folders/{folder}".format(folder=folder,)
+    expected = "folders/{folder}".format(
+        folder=folder,
+    )
     actual = ClusterControllerClient.common_folder_path(folder)
     assert expected == actual
 
@@ -2530,7 +2725,9 @@ def test_parse_common_folder_path():
 
 def test_common_organization_path():
     organization = "oyster"
-    expected = "organizations/{organization}".format(organization=organization,)
+    expected = "organizations/{organization}".format(
+        organization=organization,
+    )
     actual = ClusterControllerClient.common_organization_path(organization)
     assert expected == actual
 
@@ -2548,7 +2745,9 @@ def test_parse_common_organization_path():
 
 def test_common_project_path():
     project = "cuttlefish"
-    expected = "projects/{project}".format(project=project,)
+    expected = "projects/{project}".format(
+        project=project,
+    )
     actual = ClusterControllerClient.common_project_path(project)
     assert expected == actual
 
@@ -2568,7 +2767,8 @@ def test_common_location_path():
     project = "winkle"
     location = "nautilus"
     expected = "projects/{project}/locations/{location}".format(
-        project=project, location=location,
+        project=project,
+        location=location,
     )
     actual = ClusterControllerClient.common_location_path(project, location)
     assert expected == actual
@@ -2593,7 +2793,8 @@ def test_client_with_default_client_info():
         transports.ClusterControllerTransport, "_prep_wrapped_messages"
     ) as prep:
         client = ClusterControllerClient(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -2602,7 +2803,8 @@ def test_client_with_default_client_info():
     ) as prep:
         transport_class = ClusterControllerClient.get_transport_class()
         transport = transport_class(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -2610,7 +2812,8 @@ def test_client_with_default_client_info():
 @pytest.mark.asyncio
 async def test_transport_close_async():
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     with mock.patch.object(
         type(getattr(client.transport, "grpc_channel")), "close"

--- a/tests/unit/gapic/dataproc_v1/test_job_controller.py
+++ b/tests/unit/gapic/dataproc_v1/test_job_controller.py
@@ -92,7 +92,11 @@ def test__get_default_mtls_endpoint():
 
 
 @pytest.mark.parametrize(
-    "client_class", [JobControllerClient, JobControllerAsyncClient,]
+    "client_class",
+    [
+        JobControllerClient,
+        JobControllerAsyncClient,
+    ],
 )
 def test_job_controller_client_from_service_account_info(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -134,7 +138,11 @@ def test_job_controller_client_service_account_always_use_jwt(
 
 
 @pytest.mark.parametrize(
-    "client_class", [JobControllerClient, JobControllerAsyncClient,]
+    "client_class",
+    [
+        JobControllerClient,
+        JobControllerAsyncClient,
+    ],
 )
 def test_job_controller_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -498,7 +506,9 @@ def test_job_controller_client_client_options_scopes(
     client_class, transport_class, transport_name
 ):
     # Check the case scopes are provided.
-    options = client_options.ClientOptions(scopes=["1", "2"],)
+    options = client_options.ClientOptions(
+        scopes=["1", "2"],
+    )
     with mock.patch.object(transport_class, "__init__") as patched:
         patched.return_value = None
         client = client_class(client_options=options, transport=transport_name)
@@ -638,10 +648,17 @@ def test_job_controller_client_create_channel_credentials_file(
         )
 
 
-@pytest.mark.parametrize("request_type", [jobs.SubmitJobRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        jobs.SubmitJobRequest,
+        dict,
+    ],
+)
 def test_submit_job(request_type, transport: str = "grpc"):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -677,7 +694,8 @@ def test_submit_job_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -693,7 +711,8 @@ async def test_submit_job_async(
     transport: str = "grpc_asyncio", request_type=jobs.SubmitJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -732,7 +751,9 @@ async def test_submit_job_async_from_dict():
 
 
 def test_submit_job_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.submit_job), "__call__") as call:
@@ -762,7 +783,9 @@ def test_submit_job_flattened():
 
 
 def test_submit_job_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -827,10 +850,17 @@ async def test_submit_job_flattened_error_async():
         )
 
 
-@pytest.mark.parametrize("request_type", [jobs.SubmitJobRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        jobs.SubmitJobRequest,
+        dict,
+    ],
+)
 def test_submit_job_as_operation(request_type, transport: str = "grpc"):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -858,7 +888,8 @@ def test_submit_job_as_operation_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -876,7 +907,8 @@ async def test_submit_job_as_operation_async(
     transport: str = "grpc_asyncio", request_type=jobs.SubmitJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -908,7 +940,9 @@ async def test_submit_job_as_operation_async_from_dict():
 
 
 def test_submit_job_as_operation_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -940,7 +974,9 @@ def test_submit_job_as_operation_flattened():
 
 
 def test_submit_job_as_operation_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1009,10 +1045,17 @@ async def test_submit_job_as_operation_flattened_error_async():
         )
 
 
-@pytest.mark.parametrize("request_type", [jobs.GetJobRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        jobs.GetJobRequest,
+        dict,
+    ],
+)
 def test_get_job(request_type, transport: str = "grpc"):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1048,7 +1091,8 @@ def test_get_job_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1064,7 +1108,8 @@ async def test_get_job_async(
     transport: str = "grpc_asyncio", request_type=jobs.GetJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1103,7 +1148,9 @@ async def test_get_job_async_from_dict():
 
 
 def test_get_job_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_job), "__call__") as call:
@@ -1112,7 +1159,9 @@ def test_get_job_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.get_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1131,7 +1180,9 @@ def test_get_job_flattened():
 
 
 def test_get_job_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1159,7 +1210,9 @@ async def test_get_job_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.get_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1194,10 +1247,17 @@ async def test_get_job_flattened_error_async():
         )
 
 
-@pytest.mark.parametrize("request_type", [jobs.ListJobsRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        jobs.ListJobsRequest,
+        dict,
+    ],
+)
 def test_list_jobs(request_type, transport: str = "grpc"):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1226,7 +1286,8 @@ def test_list_jobs_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1242,7 +1303,8 @@ async def test_list_jobs_async(
     transport: str = "grpc_asyncio", request_type=jobs.ListJobsRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1253,7 +1315,9 @@ async def test_list_jobs_async(
     with mock.patch.object(type(client.transport.list_jobs), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            jobs.ListJobsResponse(next_page_token="next_page_token_value",)
+            jobs.ListJobsResponse(
+                next_page_token="next_page_token_value",
+            )
         )
         response = await client.list_jobs(request)
 
@@ -1273,7 +1337,9 @@ async def test_list_jobs_async_from_dict():
 
 
 def test_list_jobs_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_jobs), "__call__") as call:
@@ -1282,7 +1348,9 @@ def test_list_jobs_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.list_jobs(
-            project_id="project_id_value", region="region_value", filter="filter_value",
+            project_id="project_id_value",
+            region="region_value",
+            filter="filter_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1301,7 +1369,9 @@ def test_list_jobs_flattened():
 
 
 def test_list_jobs_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1331,7 +1401,9 @@ async def test_list_jobs_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.list_jobs(
-            project_id="project_id_value", region="region_value", filter="filter_value",
+            project_id="project_id_value",
+            region="region_value",
+            filter="filter_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1368,7 +1440,8 @@ async def test_list_jobs_flattened_error_async():
 
 def test_list_jobs_pager(transport_name: str = "grpc"):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials, transport=transport_name,
+        credentials=ga_credentials.AnonymousCredentials,
+        transport=transport_name,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1376,11 +1449,29 @@ def test_list_jobs_pager(transport_name: str = "grpc"):
         # Set the response to a series of pages.
         call.side_effect = (
             jobs.ListJobsResponse(
-                jobs=[jobs.Job(), jobs.Job(), jobs.Job(),], next_page_token="abc",
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+                next_page_token="abc",
             ),
-            jobs.ListJobsResponse(jobs=[], next_page_token="def",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(),], next_page_token="ghi",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(), jobs.Job(),],),
+            jobs.ListJobsResponse(
+                jobs=[],
+                next_page_token="def",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                ],
+                next_page_token="ghi",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+            ),
             RuntimeError,
         )
 
@@ -1396,7 +1487,8 @@ def test_list_jobs_pager(transport_name: str = "grpc"):
 
 def test_list_jobs_pages(transport_name: str = "grpc"):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials, transport=transport_name,
+        credentials=ga_credentials.AnonymousCredentials,
+        transport=transport_name,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1404,11 +1496,29 @@ def test_list_jobs_pages(transport_name: str = "grpc"):
         # Set the response to a series of pages.
         call.side_effect = (
             jobs.ListJobsResponse(
-                jobs=[jobs.Job(), jobs.Job(), jobs.Job(),], next_page_token="abc",
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+                next_page_token="abc",
             ),
-            jobs.ListJobsResponse(jobs=[], next_page_token="def",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(),], next_page_token="ghi",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(), jobs.Job(),],),
+            jobs.ListJobsResponse(
+                jobs=[],
+                next_page_token="def",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                ],
+                next_page_token="ghi",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+            ),
             RuntimeError,
         )
         pages = list(client.list_jobs(request={}).pages)
@@ -1418,7 +1528,9 @@ def test_list_jobs_pages(transport_name: str = "grpc"):
 
 @pytest.mark.asyncio
 async def test_list_jobs_async_pager():
-    client = JobControllerAsyncClient(credentials=ga_credentials.AnonymousCredentials,)
+    client = JobControllerAsyncClient(
+        credentials=ga_credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1427,14 +1539,34 @@ async def test_list_jobs_async_pager():
         # Set the response to a series of pages.
         call.side_effect = (
             jobs.ListJobsResponse(
-                jobs=[jobs.Job(), jobs.Job(), jobs.Job(),], next_page_token="abc",
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+                next_page_token="abc",
             ),
-            jobs.ListJobsResponse(jobs=[], next_page_token="def",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(),], next_page_token="ghi",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(), jobs.Job(),],),
+            jobs.ListJobsResponse(
+                jobs=[],
+                next_page_token="def",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                ],
+                next_page_token="ghi",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+            ),
             RuntimeError,
         )
-        async_pager = await client.list_jobs(request={},)
+        async_pager = await client.list_jobs(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -1446,7 +1578,9 @@ async def test_list_jobs_async_pager():
 
 @pytest.mark.asyncio
 async def test_list_jobs_async_pages():
-    client = JobControllerAsyncClient(credentials=ga_credentials.AnonymousCredentials,)
+    client = JobControllerAsyncClient(
+        credentials=ga_credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1455,11 +1589,29 @@ async def test_list_jobs_async_pages():
         # Set the response to a series of pages.
         call.side_effect = (
             jobs.ListJobsResponse(
-                jobs=[jobs.Job(), jobs.Job(), jobs.Job(),], next_page_token="abc",
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+                next_page_token="abc",
             ),
-            jobs.ListJobsResponse(jobs=[], next_page_token="def",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(),], next_page_token="ghi",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(), jobs.Job(),],),
+            jobs.ListJobsResponse(
+                jobs=[],
+                next_page_token="def",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                ],
+                next_page_token="ghi",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+            ),
             RuntimeError,
         )
         pages = []
@@ -1469,10 +1621,17 @@ async def test_list_jobs_async_pages():
             assert page_.raw_page.next_page_token == token
 
 
-@pytest.mark.parametrize("request_type", [jobs.UpdateJobRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        jobs.UpdateJobRequest,
+        dict,
+    ],
+)
 def test_update_job(request_type, transport: str = "grpc"):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1508,7 +1667,8 @@ def test_update_job_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1524,7 +1684,8 @@ async def test_update_job_async(
     transport: str = "grpc_asyncio", request_type=jobs.UpdateJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1562,10 +1723,17 @@ async def test_update_job_async_from_dict():
     await test_update_job_async(request_type=dict)
 
 
-@pytest.mark.parametrize("request_type", [jobs.CancelJobRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        jobs.CancelJobRequest,
+        dict,
+    ],
+)
 def test_cancel_job(request_type, transport: str = "grpc"):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1601,7 +1769,8 @@ def test_cancel_job_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1617,7 +1786,8 @@ async def test_cancel_job_async(
     transport: str = "grpc_asyncio", request_type=jobs.CancelJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1656,7 +1826,9 @@ async def test_cancel_job_async_from_dict():
 
 
 def test_cancel_job_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.cancel_job), "__call__") as call:
@@ -1665,7 +1837,9 @@ def test_cancel_job_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.cancel_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1684,7 +1858,9 @@ def test_cancel_job_flattened():
 
 
 def test_cancel_job_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1712,7 +1888,9 @@ async def test_cancel_job_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.cancel_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1747,10 +1925,17 @@ async def test_cancel_job_flattened_error_async():
         )
 
 
-@pytest.mark.parametrize("request_type", [jobs.DeleteJobRequest, dict,])
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        jobs.DeleteJobRequest,
+        dict,
+    ],
+)
 def test_delete_job(request_type, transport: str = "grpc"):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1776,7 +1961,8 @@ def test_delete_job_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1792,7 +1978,8 @@ async def test_delete_job_async(
     transport: str = "grpc_asyncio", request_type=jobs.DeleteJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1820,7 +2007,9 @@ async def test_delete_job_async_from_dict():
 
 
 def test_delete_job_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_job), "__call__") as call:
@@ -1829,7 +2018,9 @@ def test_delete_job_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.delete_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1848,7 +2039,9 @@ def test_delete_job_flattened():
 
 
 def test_delete_job_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1876,7 +2069,9 @@ async def test_delete_job_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.delete_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1918,7 +2113,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = JobControllerClient(
-            credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
@@ -1938,7 +2134,10 @@ def test_credentials_transport_error():
     options = client_options.ClientOptions()
     options.api_key = "api_key"
     with pytest.raises(ValueError):
-        client = JobControllerClient(client_options=options, transport=transport,)
+        client = JobControllerClient(
+            client_options=options,
+            transport=transport,
+        )
 
     # It is an error to provide an api_key and a credential.
     options = mock.Mock()
@@ -1954,7 +2153,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = JobControllerClient(
-            client_options={"scopes": ["1", "2"]}, transport=transport,
+            client_options={"scopes": ["1", "2"]},
+            transport=transport,
         )
 
 
@@ -1999,8 +2199,13 @@ def test_transport_adc(transport_class):
 
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
-    assert isinstance(client.transport, transports.JobControllerGrpcTransport,)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    assert isinstance(
+        client.transport,
+        transports.JobControllerGrpcTransport,
+    )
 
 
 def test_job_controller_base_transport_error():
@@ -2056,7 +2261,8 @@ def test_job_controller_base_transport_with_credentials_file():
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.JobControllerTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -2214,7 +2420,8 @@ def test_job_controller_grpc_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.JobControllerGrpcTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2226,7 +2433,8 @@ def test_job_controller_grpc_asyncio_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.JobControllerGrpcAsyncIOTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2333,12 +2541,16 @@ def test_job_controller_transport_channel_mtls_with_adc(transport_class):
 
 def test_job_controller_grpc_lro_client():
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2346,12 +2558,16 @@ def test_job_controller_grpc_lro_client():
 
 def test_job_controller_grpc_lro_async_client():
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsAsyncClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsAsyncClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2379,7 +2595,9 @@ def test_parse_common_billing_account_path():
 
 def test_common_folder_path():
     folder = "whelk"
-    expected = "folders/{folder}".format(folder=folder,)
+    expected = "folders/{folder}".format(
+        folder=folder,
+    )
     actual = JobControllerClient.common_folder_path(folder)
     assert expected == actual
 
@@ -2397,7 +2615,9 @@ def test_parse_common_folder_path():
 
 def test_common_organization_path():
     organization = "oyster"
-    expected = "organizations/{organization}".format(organization=organization,)
+    expected = "organizations/{organization}".format(
+        organization=organization,
+    )
     actual = JobControllerClient.common_organization_path(organization)
     assert expected == actual
 
@@ -2415,7 +2635,9 @@ def test_parse_common_organization_path():
 
 def test_common_project_path():
     project = "cuttlefish"
-    expected = "projects/{project}".format(project=project,)
+    expected = "projects/{project}".format(
+        project=project,
+    )
     actual = JobControllerClient.common_project_path(project)
     assert expected == actual
 
@@ -2435,7 +2657,8 @@ def test_common_location_path():
     project = "winkle"
     location = "nautilus"
     expected = "projects/{project}/locations/{location}".format(
-        project=project, location=location,
+        project=project,
+        location=location,
     )
     actual = JobControllerClient.common_location_path(project, location)
     assert expected == actual
@@ -2460,7 +2683,8 @@ def test_client_with_default_client_info():
         transports.JobControllerTransport, "_prep_wrapped_messages"
     ) as prep:
         client = JobControllerClient(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -2469,7 +2693,8 @@ def test_client_with_default_client_info():
     ) as prep:
         transport_class = JobControllerClient.get_transport_class()
         transport = transport_class(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -2477,7 +2702,8 @@ def test_client_with_default_client_info():
 @pytest.mark.asyncio
 async def test_transport_close_async():
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     with mock.patch.object(
         type(getattr(client.transport, "grpc_channel")), "close"

--- a/tests/unit/gapic/dataproc_v1/test_workflow_template_service.py
+++ b/tests/unit/gapic/dataproc_v1/test_workflow_template_service.py
@@ -100,7 +100,11 @@ def test__get_default_mtls_endpoint():
 
 
 @pytest.mark.parametrize(
-    "client_class", [WorkflowTemplateServiceClient, WorkflowTemplateServiceAsyncClient,]
+    "client_class",
+    [
+        WorkflowTemplateServiceClient,
+        WorkflowTemplateServiceAsyncClient,
+    ],
 )
 def test_workflow_template_service_client_from_service_account_info(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -142,7 +146,11 @@ def test_workflow_template_service_client_service_account_always_use_jwt(
 
 
 @pytest.mark.parametrize(
-    "client_class", [WorkflowTemplateServiceClient, WorkflowTemplateServiceAsyncClient,]
+    "client_class",
+    [
+        WorkflowTemplateServiceClient,
+        WorkflowTemplateServiceAsyncClient,
+    ],
 )
 def test_workflow_template_service_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -526,7 +534,9 @@ def test_workflow_template_service_client_client_options_scopes(
     client_class, transport_class, transport_name
 ):
     # Check the case scopes are provided.
-    options = client_options.ClientOptions(scopes=["1", "2"],)
+    options = client_options.ClientOptions(
+        scopes=["1", "2"],
+    )
     with mock.patch.object(transport_class, "__init__") as patched:
         patched.return_value = None
         client = client_class(client_options=options, transport=transport_name)
@@ -667,11 +677,16 @@ def test_workflow_template_service_client_create_channel_credentials_file(
 
 
 @pytest.mark.parametrize(
-    "request_type", [workflow_templates.CreateWorkflowTemplateRequest, dict,]
+    "request_type",
+    [
+        workflow_templates.CreateWorkflowTemplateRequest,
+        dict,
+    ],
 )
 def test_create_workflow_template(request_type, transport: str = "grpc"):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -684,7 +699,9 @@ def test_create_workflow_template(request_type, transport: str = "grpc"):
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = workflow_templates.WorkflowTemplate(
-            id="id_value", name="name_value", version=774,
+            id="id_value",
+            name="name_value",
+            version=774,
         )
         response = client.create_workflow_template(request)
 
@@ -704,7 +721,8 @@ def test_create_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -723,7 +741,8 @@ async def test_create_workflow_template_async(
     request_type=workflow_templates.CreateWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -737,7 +756,9 @@ async def test_create_workflow_template_async(
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             workflow_templates.WorkflowTemplate(
-                id="id_value", name="name_value", version=774,
+                id="id_value",
+                name="name_value",
+                version=774,
             )
         )
         response = await client.create_workflow_template(request)
@@ -784,7 +805,10 @@ def test_create_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -815,7 +839,10 @@ async def test_create_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_create_workflow_template_flattened():
@@ -915,11 +942,16 @@ async def test_create_workflow_template_flattened_error_async():
 
 
 @pytest.mark.parametrize(
-    "request_type", [workflow_templates.GetWorkflowTemplateRequest, dict,]
+    "request_type",
+    [
+        workflow_templates.GetWorkflowTemplateRequest,
+        dict,
+    ],
 )
 def test_get_workflow_template(request_type, transport: str = "grpc"):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -932,7 +964,9 @@ def test_get_workflow_template(request_type, transport: str = "grpc"):
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = workflow_templates.WorkflowTemplate(
-            id="id_value", name="name_value", version=774,
+            id="id_value",
+            name="name_value",
+            version=774,
         )
         response = client.get_workflow_template(request)
 
@@ -952,7 +986,8 @@ def test_get_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -971,7 +1006,8 @@ async def test_get_workflow_template_async(
     request_type=workflow_templates.GetWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -985,7 +1021,9 @@ async def test_get_workflow_template_async(
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             workflow_templates.WorkflowTemplate(
-                id="id_value", name="name_value", version=774,
+                id="id_value",
+                name="name_value",
+                version=774,
             )
         )
         response = await client.get_workflow_template(request)
@@ -1032,7 +1070,10 @@ def test_get_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1063,7 +1104,10 @@ async def test_get_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_get_workflow_template_flattened():
@@ -1079,7 +1123,9 @@ def test_get_workflow_template_flattened():
         call.return_value = workflow_templates.WorkflowTemplate()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.get_workflow_template(name="name_value",)
+        client.get_workflow_template(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1099,7 +1145,8 @@ def test_get_workflow_template_flattened_error():
     # fields is an error.
     with pytest.raises(ValueError):
         client.get_workflow_template(
-            workflow_templates.GetWorkflowTemplateRequest(), name="name_value",
+            workflow_templates.GetWorkflowTemplateRequest(),
+            name="name_value",
         )
 
 
@@ -1121,7 +1168,9 @@ async def test_get_workflow_template_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.get_workflow_template(name="name_value",)
+        response = await client.get_workflow_template(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1142,16 +1191,22 @@ async def test_get_workflow_template_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.get_workflow_template(
-            workflow_templates.GetWorkflowTemplateRequest(), name="name_value",
+            workflow_templates.GetWorkflowTemplateRequest(),
+            name="name_value",
         )
 
 
 @pytest.mark.parametrize(
-    "request_type", [workflow_templates.InstantiateWorkflowTemplateRequest, dict,]
+    "request_type",
+    [
+        workflow_templates.InstantiateWorkflowTemplateRequest,
+        dict,
+    ],
 )
 def test_instantiate_workflow_template(request_type, transport: str = "grpc"):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1179,7 +1234,8 @@ def test_instantiate_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1198,7 +1254,8 @@ async def test_instantiate_workflow_template_async(
     request_type=workflow_templates.InstantiateWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1254,7 +1311,10 @@ def test_instantiate_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1285,7 +1345,10 @@ async def test_instantiate_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_instantiate_workflow_template_flattened():
@@ -1302,7 +1365,8 @@ def test_instantiate_workflow_template_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.instantiate_workflow_template(
-            name="name_value", parameters={"key_value": "value_value"},
+            name="name_value",
+            parameters={"key_value": "value_value"},
         )
 
         # Establish that the underlying call was made with the expected
@@ -1351,7 +1415,8 @@ async def test_instantiate_workflow_template_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.instantiate_workflow_template(
-            name="name_value", parameters={"key_value": "value_value"},
+            name="name_value",
+            parameters={"key_value": "value_value"},
         )
 
         # Establish that the underlying call was made with the expected
@@ -1383,11 +1448,16 @@ async def test_instantiate_workflow_template_flattened_error_async():
 
 
 @pytest.mark.parametrize(
-    "request_type", [workflow_templates.InstantiateInlineWorkflowTemplateRequest, dict,]
+    "request_type",
+    [
+        workflow_templates.InstantiateInlineWorkflowTemplateRequest,
+        dict,
+    ],
 )
 def test_instantiate_inline_workflow_template(request_type, transport: str = "grpc"):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1415,7 +1485,8 @@ def test_instantiate_inline_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1434,7 +1505,8 @@ async def test_instantiate_inline_workflow_template_async(
     request_type=workflow_templates.InstantiateInlineWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1490,7 +1562,10 @@ def test_instantiate_inline_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1521,7 +1596,10 @@ async def test_instantiate_inline_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_instantiate_inline_workflow_template_flattened():
@@ -1621,11 +1699,16 @@ async def test_instantiate_inline_workflow_template_flattened_error_async():
 
 
 @pytest.mark.parametrize(
-    "request_type", [workflow_templates.UpdateWorkflowTemplateRequest, dict,]
+    "request_type",
+    [
+        workflow_templates.UpdateWorkflowTemplateRequest,
+        dict,
+    ],
 )
 def test_update_workflow_template(request_type, transport: str = "grpc"):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1638,7 +1721,9 @@ def test_update_workflow_template(request_type, transport: str = "grpc"):
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = workflow_templates.WorkflowTemplate(
-            id="id_value", name="name_value", version=774,
+            id="id_value",
+            name="name_value",
+            version=774,
         )
         response = client.update_workflow_template(request)
 
@@ -1658,7 +1743,8 @@ def test_update_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1677,7 +1763,8 @@ async def test_update_workflow_template_async(
     request_type=workflow_templates.UpdateWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1691,7 +1778,9 @@ async def test_update_workflow_template_async(
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             workflow_templates.WorkflowTemplate(
-                id="id_value", name="name_value", version=774,
+                id="id_value",
+                name="name_value",
+                version=774,
             )
         )
         response = await client.update_workflow_template(request)
@@ -1738,9 +1827,10 @@ def test_update_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "template.name=template.name/value",) in kw[
-        "metadata"
-    ]
+    assert (
+        "x-goog-request-params",
+        "template.name=template.name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1771,9 +1861,10 @@ async def test_update_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "template.name=template.name/value",) in kw[
-        "metadata"
-    ]
+    assert (
+        "x-goog-request-params",
+        "template.name=template.name/value",
+    ) in kw["metadata"]
 
 
 def test_update_workflow_template_flattened():
@@ -1863,11 +1954,16 @@ async def test_update_workflow_template_flattened_error_async():
 
 
 @pytest.mark.parametrize(
-    "request_type", [workflow_templates.ListWorkflowTemplatesRequest, dict,]
+    "request_type",
+    [
+        workflow_templates.ListWorkflowTemplatesRequest,
+        dict,
+    ],
 )
 def test_list_workflow_templates(request_type, transport: str = "grpc"):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1898,7 +1994,8 @@ def test_list_workflow_templates_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1917,7 +2014,8 @@ async def test_list_workflow_templates_async(
     request_type=workflow_templates.ListWorkflowTemplatesRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1976,7 +2074,10 @@ def test_list_workflow_templates_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -2007,7 +2108,10 @@ async def test_list_workflow_templates_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_list_workflow_templates_flattened():
@@ -2023,7 +2127,9 @@ def test_list_workflow_templates_flattened():
         call.return_value = workflow_templates.ListWorkflowTemplatesResponse()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.list_workflow_templates(parent="parent_value",)
+        client.list_workflow_templates(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2043,7 +2149,8 @@ def test_list_workflow_templates_flattened_error():
     # fields is an error.
     with pytest.raises(ValueError):
         client.list_workflow_templates(
-            workflow_templates.ListWorkflowTemplatesRequest(), parent="parent_value",
+            workflow_templates.ListWorkflowTemplatesRequest(),
+            parent="parent_value",
         )
 
 
@@ -2065,7 +2172,9 @@ async def test_list_workflow_templates_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.list_workflow_templates(parent="parent_value",)
+        response = await client.list_workflow_templates(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2086,13 +2195,15 @@ async def test_list_workflow_templates_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.list_workflow_templates(
-            workflow_templates.ListWorkflowTemplatesRequest(), parent="parent_value",
+            workflow_templates.ListWorkflowTemplatesRequest(),
+            parent="parent_value",
         )
 
 
 def test_list_workflow_templates_pager(transport_name: str = "grpc"):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials, transport=transport_name,
+        credentials=ga_credentials.AnonymousCredentials,
+        transport=transport_name,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2110,10 +2221,13 @@ def test_list_workflow_templates_pager(transport_name: str = "grpc"):
                 next_page_token="abc",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[], next_page_token="def",
+                templates=[],
+                next_page_token="def",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[workflow_templates.WorkflowTemplate(),],
+                templates=[
+                    workflow_templates.WorkflowTemplate(),
+                ],
                 next_page_token="ghi",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
@@ -2140,7 +2254,8 @@ def test_list_workflow_templates_pager(transport_name: str = "grpc"):
 
 def test_list_workflow_templates_pages(transport_name: str = "grpc"):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials, transport=transport_name,
+        credentials=ga_credentials.AnonymousCredentials,
+        transport=transport_name,
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2158,10 +2273,13 @@ def test_list_workflow_templates_pages(transport_name: str = "grpc"):
                 next_page_token="abc",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[], next_page_token="def",
+                templates=[],
+                next_page_token="def",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[workflow_templates.WorkflowTemplate(),],
+                templates=[
+                    workflow_templates.WorkflowTemplate(),
+                ],
                 next_page_token="ghi",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
@@ -2200,10 +2318,13 @@ async def test_list_workflow_templates_async_pager():
                 next_page_token="abc",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[], next_page_token="def",
+                templates=[],
+                next_page_token="def",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[workflow_templates.WorkflowTemplate(),],
+                templates=[
+                    workflow_templates.WorkflowTemplate(),
+                ],
                 next_page_token="ghi",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
@@ -2214,7 +2335,9 @@ async def test_list_workflow_templates_async_pager():
             ),
             RuntimeError,
         )
-        async_pager = await client.list_workflow_templates(request={},)
+        async_pager = await client.list_workflow_templates(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -2249,10 +2372,13 @@ async def test_list_workflow_templates_async_pages():
                 next_page_token="abc",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[], next_page_token="def",
+                templates=[],
+                next_page_token="def",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[workflow_templates.WorkflowTemplate(),],
+                templates=[
+                    workflow_templates.WorkflowTemplate(),
+                ],
                 next_page_token="ghi",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
@@ -2271,11 +2397,16 @@ async def test_list_workflow_templates_async_pages():
 
 
 @pytest.mark.parametrize(
-    "request_type", [workflow_templates.DeleteWorkflowTemplateRequest, dict,]
+    "request_type",
+    [
+        workflow_templates.DeleteWorkflowTemplateRequest,
+        dict,
+    ],
 )
 def test_delete_workflow_template(request_type, transport: str = "grpc"):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2303,7 +2434,8 @@ def test_delete_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2322,7 +2454,8 @@ async def test_delete_workflow_template_async(
     request_type=workflow_templates.DeleteWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2376,7 +2509,10 @@ def test_delete_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -2405,7 +2541,10 @@ async def test_delete_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_delete_workflow_template_flattened():
@@ -2421,7 +2560,9 @@ def test_delete_workflow_template_flattened():
         call.return_value = None
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.delete_workflow_template(name="name_value",)
+        client.delete_workflow_template(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2441,7 +2582,8 @@ def test_delete_workflow_template_flattened_error():
     # fields is an error.
     with pytest.raises(ValueError):
         client.delete_workflow_template(
-            workflow_templates.DeleteWorkflowTemplateRequest(), name="name_value",
+            workflow_templates.DeleteWorkflowTemplateRequest(),
+            name="name_value",
         )
 
 
@@ -2461,7 +2603,9 @@ async def test_delete_workflow_template_flattened_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.delete_workflow_template(name="name_value",)
+        response = await client.delete_workflow_template(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2482,7 +2626,8 @@ async def test_delete_workflow_template_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.delete_workflow_template(
-            workflow_templates.DeleteWorkflowTemplateRequest(), name="name_value",
+            workflow_templates.DeleteWorkflowTemplateRequest(),
+            name="name_value",
         )
 
 
@@ -2493,7 +2638,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = WorkflowTemplateServiceClient(
-            credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
@@ -2514,7 +2660,8 @@ def test_credentials_transport_error():
     options.api_key = "api_key"
     with pytest.raises(ValueError):
         client = WorkflowTemplateServiceClient(
-            client_options=options, transport=transport,
+            client_options=options,
+            transport=transport,
         )
 
     # It is an error to provide an api_key and a credential.
@@ -2531,7 +2678,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = WorkflowTemplateServiceClient(
-            client_options={"scopes": ["1", "2"]}, transport=transport,
+            client_options={"scopes": ["1", "2"]},
+            transport=transport,
         )
 
 
@@ -2580,7 +2728,8 @@ def test_transport_grpc_default():
         credentials=ga_credentials.AnonymousCredentials(),
     )
     assert isinstance(
-        client.transport, transports.WorkflowTemplateServiceGrpcTransport,
+        client.transport,
+        transports.WorkflowTemplateServiceGrpcTransport,
     )
 
 
@@ -2637,7 +2786,8 @@ def test_workflow_template_service_base_transport_with_credentials_file():
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.WorkflowTemplateServiceTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -2799,7 +2949,8 @@ def test_workflow_template_service_grpc_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.WorkflowTemplateServiceGrpcTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2811,7 +2962,8 @@ def test_workflow_template_service_grpc_asyncio_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.WorkflowTemplateServiceGrpcAsyncIOTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2920,12 +3072,16 @@ def test_workflow_template_service_transport_channel_mtls_with_adc(transport_cla
 
 def test_workflow_template_service_grpc_lro_client():
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2933,12 +3089,16 @@ def test_workflow_template_service_grpc_lro_client():
 
 def test_workflow_template_service_grpc_lro_async_client():
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsAsyncClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsAsyncClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2949,7 +3109,9 @@ def test_cluster_path():
     location = "clam"
     cluster = "whelk"
     expected = "projects/{project}/locations/{location}/clusters/{cluster}".format(
-        project=project, location=location, cluster=cluster,
+        project=project,
+        location=location,
+        cluster=cluster,
     )
     actual = WorkflowTemplateServiceClient.cluster_path(project, location, cluster)
     assert expected == actual
@@ -2973,7 +3135,9 @@ def test_service_path():
     location = "mussel"
     service = "winkle"
     expected = "projects/{project}/locations/{location}/services/{service}".format(
-        project=project, location=location, service=service,
+        project=project,
+        location=location,
+        service=service,
     )
     actual = WorkflowTemplateServiceClient.service_path(project, location, service)
     assert expected == actual
@@ -2997,7 +3161,9 @@ def test_workflow_template_path():
     region = "clam"
     workflow_template = "whelk"
     expected = "projects/{project}/regions/{region}/workflowTemplates/{workflow_template}".format(
-        project=project, region=region, workflow_template=workflow_template,
+        project=project,
+        region=region,
+        workflow_template=workflow_template,
     )
     actual = WorkflowTemplateServiceClient.workflow_template_path(
         project, region, workflow_template
@@ -3040,7 +3206,9 @@ def test_parse_common_billing_account_path():
 
 def test_common_folder_path():
     folder = "winkle"
-    expected = "folders/{folder}".format(folder=folder,)
+    expected = "folders/{folder}".format(
+        folder=folder,
+    )
     actual = WorkflowTemplateServiceClient.common_folder_path(folder)
     assert expected == actual
 
@@ -3058,7 +3226,9 @@ def test_parse_common_folder_path():
 
 def test_common_organization_path():
     organization = "scallop"
-    expected = "organizations/{organization}".format(organization=organization,)
+    expected = "organizations/{organization}".format(
+        organization=organization,
+    )
     actual = WorkflowTemplateServiceClient.common_organization_path(organization)
     assert expected == actual
 
@@ -3076,7 +3246,9 @@ def test_parse_common_organization_path():
 
 def test_common_project_path():
     project = "squid"
-    expected = "projects/{project}".format(project=project,)
+    expected = "projects/{project}".format(
+        project=project,
+    )
     actual = WorkflowTemplateServiceClient.common_project_path(project)
     assert expected == actual
 
@@ -3096,7 +3268,8 @@ def test_common_location_path():
     project = "whelk"
     location = "octopus"
     expected = "projects/{project}/locations/{location}".format(
-        project=project, location=location,
+        project=project,
+        location=location,
     )
     actual = WorkflowTemplateServiceClient.common_location_path(project, location)
     assert expected == actual
@@ -3121,7 +3294,8 @@ def test_client_with_default_client_info():
         transports.WorkflowTemplateServiceTransport, "_prep_wrapped_messages"
     ) as prep:
         client = WorkflowTemplateServiceClient(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -3130,7 +3304,8 @@ def test_client_with_default_client_info():
     ) as prep:
         transport_class = WorkflowTemplateServiceClient.get_transport_class()
         transport = transport_class(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -3138,7 +3313,8 @@ def test_client_with_default_client_info():
 @pytest.mark.asyncio
 async def test_transport_close_async():
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     with mock.patch.object(
         type(getattr(client.transport, "grpc_channel")), "close"


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v3**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566