### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v2 release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -361,7 +361,10 @@ texinfo_documents = [
 intersphinx_mapping = {
     "python": ("https://python.readthedocs.org/en/latest/", None),
     "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None,),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
     "grpc": ("https://grpc.github.io/grpc/python/", None),
     "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),

--- a/google/cloud/dataproc_v1/services/autoscaling_policy_service/async_client.py
+++ b/google/cloud/dataproc_v1/services/autoscaling_policy_service/async_client.py
@@ -259,7 +259,12 @@ class AutoscalingPolicyServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -345,7 +350,12 @@ class AutoscalingPolicyServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -436,7 +446,12 @@ class AutoscalingPolicyServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -530,12 +545,20 @@ class AutoscalingPolicyServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListAutoscalingPoliciesAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -618,13 +641,18 @@ class AutoscalingPolicyServiceAsyncClient:
 
         # Send the request.
         await rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/autoscaling_policy_service/client.py
+++ b/google/cloud/dataproc_v1/services/autoscaling_policy_service/client.py
@@ -52,7 +52,8 @@ class AutoscalingPolicyServiceClientMeta(type):
     _transport_registry["grpc_asyncio"] = AutoscalingPolicyServiceGrpcAsyncIOTransport
 
     def get_transport_class(
-        cls, label: str = None,
+        cls,
+        label: str = None,
     ) -> Type[AutoscalingPolicyServiceTransport]:
         """Returns an appropriate transport class.
 
@@ -161,11 +162,15 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
 
     @staticmethod
     def autoscaling_policy_path(
-        project: str, location: str, autoscaling_policy: str,
+        project: str,
+        location: str,
+        autoscaling_policy: str,
     ) -> str:
         """Returns a fully-qualified autoscaling_policy string."""
         return "projects/{project}/locations/{location}/autoscalingPolicies/{autoscaling_policy}".format(
-            project=project, location=location, autoscaling_policy=autoscaling_policy,
+            project=project,
+            location=location,
+            autoscaling_policy=autoscaling_policy,
         )
 
     @staticmethod
@@ -178,7 +183,9 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_billing_account_path(billing_account: str,) -> str:
+    def common_billing_account_path(
+        billing_account: str,
+    ) -> str:
         """Returns a fully-qualified billing_account string."""
         return "billingAccounts/{billing_account}".format(
             billing_account=billing_account,
@@ -191,9 +198,13 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_folder_path(folder: str,) -> str:
+    def common_folder_path(
+        folder: str,
+    ) -> str:
         """Returns a fully-qualified folder string."""
-        return "folders/{folder}".format(folder=folder,)
+        return "folders/{folder}".format(
+            folder=folder,
+        )
 
     @staticmethod
     def parse_common_folder_path(path: str) -> Dict[str, str]:
@@ -202,9 +213,13 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_organization_path(organization: str,) -> str:
+    def common_organization_path(
+        organization: str,
+    ) -> str:
         """Returns a fully-qualified organization string."""
-        return "organizations/{organization}".format(organization=organization,)
+        return "organizations/{organization}".format(
+            organization=organization,
+        )
 
     @staticmethod
     def parse_common_organization_path(path: str) -> Dict[str, str]:
@@ -213,9 +228,13 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_project_path(project: str,) -> str:
+    def common_project_path(
+        project: str,
+    ) -> str:
         """Returns a fully-qualified project string."""
-        return "projects/{project}".format(project=project,)
+        return "projects/{project}".format(
+            project=project,
+        )
 
     @staticmethod
     def parse_common_project_path(path: str) -> Dict[str, str]:
@@ -224,10 +243,14 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_location_path(project: str, location: str,) -> str:
+    def common_location_path(
+        project: str,
+        location: str,
+    ) -> str:
         """Returns a fully-qualified location string."""
         return "projects/{project}/locations/{location}".format(
-            project=project, location=location,
+            project=project,
+            location=location,
         )
 
     @staticmethod
@@ -445,7 +468,12 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -523,7 +551,12 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -604,7 +637,12 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -690,12 +728,20 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListAutoscalingPoliciesPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -780,13 +826,18 @@ class AutoscalingPolicyServiceClient(metaclass=AutoscalingPolicyServiceClientMet
 
         # Send the request.
         rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/base.py
+++ b/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/base.py
@@ -31,7 +31,9 @@ from google.protobuf import empty_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc.py
+++ b/google/cloud/dataproc_v1/services/autoscaling_policy_service/transports/grpc.py
@@ -223,8 +223,7 @@ class AutoscalingPolicyServiceGrpcTransport(AutoscalingPolicyServiceTransport):
 
     @property
     def grpc_channel(self) -> grpc.Channel:
-        """Return the channel designed to connect to this service.
-        """
+        """Return the channel designed to connect to this service."""
         return self._grpc_channel
 
     @property

--- a/google/cloud/dataproc_v1/services/cluster_controller/async_client.py
+++ b/google/cloud/dataproc_v1/services/cluster_controller/async_client.py
@@ -262,7 +262,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -446,7 +451,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -498,7 +508,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -550,7 +565,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -666,7 +686,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -771,7 +796,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -893,12 +923,20 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListClustersAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -1002,7 +1040,12 @@ class ClusterControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -1018,7 +1061,9 @@ class ClusterControllerAsyncClient:
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/cluster_controller/client.py
+++ b/google/cloud/dataproc_v1/services/cluster_controller/client.py
@@ -57,7 +57,8 @@ class ClusterControllerClientMeta(type):
     _transport_registry["grpc_asyncio"] = ClusterControllerGrpcAsyncIOTransport
 
     def get_transport_class(
-        cls, label: str = None,
+        cls,
+        label: str = None,
     ) -> Type[ClusterControllerTransport]:
         """Returns an appropriate transport class.
 
@@ -165,10 +166,16 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return self._transport
 
     @staticmethod
-    def cluster_path(project: str, location: str, cluster: str,) -> str:
+    def cluster_path(
+        project: str,
+        location: str,
+        cluster: str,
+    ) -> str:
         """Returns a fully-qualified cluster string."""
         return "projects/{project}/locations/{location}/clusters/{cluster}".format(
-            project=project, location=location, cluster=cluster,
+            project=project,
+            location=location,
+            cluster=cluster,
         )
 
     @staticmethod
@@ -181,10 +188,16 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def service_path(project: str, location: str, service: str,) -> str:
+    def service_path(
+        project: str,
+        location: str,
+        service: str,
+    ) -> str:
         """Returns a fully-qualified service string."""
         return "projects/{project}/locations/{location}/services/{service}".format(
-            project=project, location=location, service=service,
+            project=project,
+            location=location,
+            service=service,
         )
 
     @staticmethod
@@ -197,7 +210,9 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_billing_account_path(billing_account: str,) -> str:
+    def common_billing_account_path(
+        billing_account: str,
+    ) -> str:
         """Returns a fully-qualified billing_account string."""
         return "billingAccounts/{billing_account}".format(
             billing_account=billing_account,
@@ -210,9 +225,13 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_folder_path(folder: str,) -> str:
+    def common_folder_path(
+        folder: str,
+    ) -> str:
         """Returns a fully-qualified folder string."""
-        return "folders/{folder}".format(folder=folder,)
+        return "folders/{folder}".format(
+            folder=folder,
+        )
 
     @staticmethod
     def parse_common_folder_path(path: str) -> Dict[str, str]:
@@ -221,9 +240,13 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_organization_path(organization: str,) -> str:
+    def common_organization_path(
+        organization: str,
+    ) -> str:
         """Returns a fully-qualified organization string."""
-        return "organizations/{organization}".format(organization=organization,)
+        return "organizations/{organization}".format(
+            organization=organization,
+        )
 
     @staticmethod
     def parse_common_organization_path(path: str) -> Dict[str, str]:
@@ -232,9 +255,13 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_project_path(project: str,) -> str:
+    def common_project_path(
+        project: str,
+    ) -> str:
         """Returns a fully-qualified project string."""
-        return "projects/{project}".format(project=project,)
+        return "projects/{project}".format(
+            project=project,
+        )
 
     @staticmethod
     def parse_common_project_path(path: str) -> Dict[str, str]:
@@ -243,10 +270,14 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_location_path(project: str, location: str,) -> str:
+    def common_location_path(
+        project: str,
+        location: str,
+    ) -> str:
         """Returns a fully-qualified location string."""
         return "projects/{project}/locations/{location}".format(
-            project=project, location=location,
+            project=project,
+            location=location,
         )
 
     @staticmethod
@@ -458,7 +489,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.create_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -633,7 +669,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.update_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -686,7 +727,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.stop_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -739,7 +785,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.start_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -846,7 +897,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.delete_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -940,7 +996,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.get_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1051,12 +1112,20 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.list_clusters]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListClustersPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -1151,7 +1220,12 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.diagnose_cluster]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -1167,7 +1241,9 @@ class ClusterControllerClient(metaclass=ClusterControllerClientMeta):
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/cluster_controller/transports/base.py
+++ b/google/cloud/dataproc_v1/services/cluster_controller/transports/base.py
@@ -32,7 +32,9 @@ from google.longrunning import operations_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
@@ -183,10 +185,14 @@ class ClusterControllerTransport(abc.ABC):
                 client_info=client_info,
             ),
             self.stop_cluster: gapic_v1.method.wrap_method(
-                self.stop_cluster, default_timeout=None, client_info=client_info,
+                self.stop_cluster,
+                default_timeout=None,
+                client_info=client_info,
             ),
             self.start_cluster: gapic_v1.method.wrap_method(
-                self.start_cluster, default_timeout=None, client_info=client_info,
+                self.start_cluster,
+                default_timeout=None,
+                client_info=client_info,
             ),
             self.delete_cluster: gapic_v1.method.wrap_method(
                 self.delete_cluster,

--- a/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc.py
+++ b/google/cloud/dataproc_v1/services/cluster_controller/transports/grpc.py
@@ -225,8 +225,7 @@ class ClusterControllerGrpcTransport(ClusterControllerTransport):
 
     @property
     def grpc_channel(self) -> grpc.Channel:
-        """Return the channel designed to connect to this service.
-        """
+        """Return the channel designed to connect to this service."""
         return self._grpc_channel
 
     @property

--- a/google/cloud/dataproc_v1/services/job_controller/async_client.py
+++ b/google/cloud/dataproc_v1/services/job_controller/async_client.py
@@ -246,7 +246,12 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -341,7 +346,12 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -443,7 +453,12 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -556,12 +571,20 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListJobsAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -611,7 +634,12 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -707,7 +735,12 @@ class JobControllerAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -795,13 +828,18 @@ class JobControllerAsyncClient:
 
         # Send the request.
         await rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/job_controller/client.py
+++ b/google/cloud/dataproc_v1/services/job_controller/client.py
@@ -51,7 +51,10 @@ class JobControllerClientMeta(type):
     _transport_registry["grpc"] = JobControllerGrpcTransport
     _transport_registry["grpc_asyncio"] = JobControllerGrpcAsyncIOTransport
 
-    def get_transport_class(cls, label: str = None,) -> Type[JobControllerTransport]:
+    def get_transport_class(
+        cls,
+        label: str = None,
+    ) -> Type[JobControllerTransport]:
         """Returns an appropriate transport class.
 
         Args:
@@ -156,7 +159,9 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         return self._transport
 
     @staticmethod
-    def common_billing_account_path(billing_account: str,) -> str:
+    def common_billing_account_path(
+        billing_account: str,
+    ) -> str:
         """Returns a fully-qualified billing_account string."""
         return "billingAccounts/{billing_account}".format(
             billing_account=billing_account,
@@ -169,9 +174,13 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_folder_path(folder: str,) -> str:
+    def common_folder_path(
+        folder: str,
+    ) -> str:
         """Returns a fully-qualified folder string."""
-        return "folders/{folder}".format(folder=folder,)
+        return "folders/{folder}".format(
+            folder=folder,
+        )
 
     @staticmethod
     def parse_common_folder_path(path: str) -> Dict[str, str]:
@@ -180,9 +189,13 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_organization_path(organization: str,) -> str:
+    def common_organization_path(
+        organization: str,
+    ) -> str:
         """Returns a fully-qualified organization string."""
-        return "organizations/{organization}".format(organization=organization,)
+        return "organizations/{organization}".format(
+            organization=organization,
+        )
 
     @staticmethod
     def parse_common_organization_path(path: str) -> Dict[str, str]:
@@ -191,9 +204,13 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_project_path(project: str,) -> str:
+    def common_project_path(
+        project: str,
+    ) -> str:
         """Returns a fully-qualified project string."""
-        return "projects/{project}".format(project=project,)
+        return "projects/{project}".format(
+            project=project,
+        )
 
     @staticmethod
     def parse_common_project_path(path: str) -> Dict[str, str]:
@@ -202,10 +219,14 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_location_path(project: str, location: str,) -> str:
+    def common_location_path(
+        project: str,
+        location: str,
+    ) -> str:
         """Returns a fully-qualified location string."""
         return "projects/{project}/locations/{location}".format(
-            project=project, location=location,
+            project=project,
+            location=location,
         )
 
     @staticmethod
@@ -410,7 +431,12 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.submit_job]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -496,7 +522,12 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.submit_job_as_operation]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -587,7 +618,12 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.get_job]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -689,12 +725,20 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.list_jobs]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListJobsPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -736,7 +780,12 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.update_job]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -821,7 +870,12 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
         rpc = self._transport._wrapped_methods[self._transport.cancel_job]
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -900,13 +954,18 @@ class JobControllerClient(metaclass=JobControllerClientMeta):
 
         # Send the request.
         rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/job_controller/transports/base.py
+++ b/google/cloud/dataproc_v1/services/job_controller/transports/base.py
@@ -33,7 +33,9 @@ from google.protobuf import empty_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/job_controller/transports/grpc.py
+++ b/google/cloud/dataproc_v1/services/job_controller/transports/grpc.py
@@ -225,8 +225,7 @@ class JobControllerGrpcTransport(JobControllerTransport):
 
     @property
     def grpc_channel(self) -> grpc.Channel:
-        """Return the channel designed to connect to this service.
-        """
+        """Return the channel designed to connect to this service."""
         return self._grpc_channel
 
     @property

--- a/google/cloud/dataproc_v1/services/workflow_template_service/async_client.py
+++ b/google/cloud/dataproc_v1/services/workflow_template_service/async_client.py
@@ -276,7 +276,12 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -371,7 +376,12 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -512,7 +522,12 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -660,7 +675,12 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation_async.from_gapic(
@@ -754,7 +774,12 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -850,12 +875,20 @@ class WorkflowTemplateServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListWorkflowTemplatesAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -945,13 +978,18 @@ class WorkflowTemplateServiceAsyncClient:
 
         # Send the request.
         await rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/workflow_template_service/client.py
+++ b/google/cloud/dataproc_v1/services/workflow_template_service/client.py
@@ -57,7 +57,8 @@ class WorkflowTemplateServiceClientMeta(type):
     _transport_registry["grpc_asyncio"] = WorkflowTemplateServiceGrpcAsyncIOTransport
 
     def get_transport_class(
-        cls, label: str = None,
+        cls,
+        label: str = None,
     ) -> Type[WorkflowTemplateServiceTransport]:
         """Returns an appropriate transport class.
 
@@ -165,10 +166,16 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return self._transport
 
     @staticmethod
-    def cluster_path(project: str, location: str, cluster: str,) -> str:
+    def cluster_path(
+        project: str,
+        location: str,
+        cluster: str,
+    ) -> str:
         """Returns a fully-qualified cluster string."""
         return "projects/{project}/locations/{location}/clusters/{cluster}".format(
-            project=project, location=location, cluster=cluster,
+            project=project,
+            location=location,
+            cluster=cluster,
         )
 
     @staticmethod
@@ -181,10 +188,16 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def service_path(project: str, location: str, service: str,) -> str:
+    def service_path(
+        project: str,
+        location: str,
+        service: str,
+    ) -> str:
         """Returns a fully-qualified service string."""
         return "projects/{project}/locations/{location}/services/{service}".format(
-            project=project, location=location, service=service,
+            project=project,
+            location=location,
+            service=service,
         )
 
     @staticmethod
@@ -198,11 +211,15 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
 
     @staticmethod
     def workflow_template_path(
-        project: str, region: str, workflow_template: str,
+        project: str,
+        region: str,
+        workflow_template: str,
     ) -> str:
         """Returns a fully-qualified workflow_template string."""
         return "projects/{project}/regions/{region}/workflowTemplates/{workflow_template}".format(
-            project=project, region=region, workflow_template=workflow_template,
+            project=project,
+            region=region,
+            workflow_template=workflow_template,
         )
 
     @staticmethod
@@ -215,7 +232,9 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_billing_account_path(billing_account: str,) -> str:
+    def common_billing_account_path(
+        billing_account: str,
+    ) -> str:
         """Returns a fully-qualified billing_account string."""
         return "billingAccounts/{billing_account}".format(
             billing_account=billing_account,
@@ -228,9 +247,13 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_folder_path(folder: str,) -> str:
+    def common_folder_path(
+        folder: str,
+    ) -> str:
         """Returns a fully-qualified folder string."""
-        return "folders/{folder}".format(folder=folder,)
+        return "folders/{folder}".format(
+            folder=folder,
+        )
 
     @staticmethod
     def parse_common_folder_path(path: str) -> Dict[str, str]:
@@ -239,9 +262,13 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_organization_path(organization: str,) -> str:
+    def common_organization_path(
+        organization: str,
+    ) -> str:
         """Returns a fully-qualified organization string."""
-        return "organizations/{organization}".format(organization=organization,)
+        return "organizations/{organization}".format(
+            organization=organization,
+        )
 
     @staticmethod
     def parse_common_organization_path(path: str) -> Dict[str, str]:
@@ -250,9 +277,13 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_project_path(project: str,) -> str:
+    def common_project_path(
+        project: str,
+    ) -> str:
         """Returns a fully-qualified project string."""
-        return "projects/{project}".format(project=project,)
+        return "projects/{project}".format(
+            project=project,
+        )
 
     @staticmethod
     def parse_common_project_path(path: str) -> Dict[str, str]:
@@ -261,10 +292,14 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         return m.groupdict() if m else {}
 
     @staticmethod
-    def common_location_path(project: str, location: str,) -> str:
+    def common_location_path(
+        project: str,
+        location: str,
+    ) -> str:
         """Returns a fully-qualified location string."""
         return "projects/{project}/locations/{location}".format(
-            project=project, location=location,
+            project=project,
+            location=location,
         )
 
     @staticmethod
@@ -479,7 +514,12 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -563,7 +603,12 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -698,7 +743,12 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -843,7 +893,12 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Wrap the response in an operation future.
         response = operation.from_gapic(
@@ -928,7 +983,12 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1013,12 +1073,20 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListWorkflowTemplatesPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -1099,13 +1167,18 @@ class WorkflowTemplateServiceClient(metaclass=WorkflowTemplateServiceClientMeta)
 
         # Send the request.
         rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/workflow_template_service/transports/base.py
+++ b/google/cloud/dataproc_v1/services/workflow_template_service/transports/base.py
@@ -33,7 +33,9 @@ from google.protobuf import empty_pb2  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution("google-cloud-dataproc",).version,
+        gapic_version=pkg_resources.get_distribution(
+            "google-cloud-dataproc",
+        ).version,
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc.py
+++ b/google/cloud/dataproc_v1/services/workflow_template_service/transports/grpc.py
@@ -226,8 +226,7 @@ class WorkflowTemplateServiceGrpcTransport(WorkflowTemplateServiceTransport):
 
     @property
     def grpc_channel(self) -> grpc.Channel:
-        """Return the channel designed to connect to this service.
-        """
+        """Return the channel designed to connect to this service."""
         return self._grpc_channel
 
     @property

--- a/google/cloud/dataproc_v1/types/autoscaling_policies.py
+++ b/google/cloud/dataproc_v1/types/autoscaling_policies.py
@@ -69,16 +69,29 @@ class AutoscalingPolicy(proto.Message):
             operate for secondary workers.
     """
 
-    id = proto.Field(proto.STRING, number=1,)
-    name = proto.Field(proto.STRING, number=2,)
+    id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
     basic_algorithm = proto.Field(
-        proto.MESSAGE, number=3, oneof="algorithm", message="BasicAutoscalingAlgorithm",
+        proto.MESSAGE,
+        number=3,
+        oneof="algorithm",
+        message="BasicAutoscalingAlgorithm",
     )
     worker_config = proto.Field(
-        proto.MESSAGE, number=4, message="InstanceGroupAutoscalingPolicyConfig",
+        proto.MESSAGE,
+        number=4,
+        message="InstanceGroupAutoscalingPolicyConfig",
     )
     secondary_worker_config = proto.Field(
-        proto.MESSAGE, number=5, message="InstanceGroupAutoscalingPolicyConfig",
+        proto.MESSAGE,
+        number=5,
+        message="InstanceGroupAutoscalingPolicyConfig",
     )
 
 
@@ -96,10 +109,14 @@ class BasicAutoscalingAlgorithm(proto.Message):
     """
 
     yarn_config = proto.Field(
-        proto.MESSAGE, number=1, message="BasicYarnAutoscalingConfig",
+        proto.MESSAGE,
+        number=1,
+        message="BasicYarnAutoscalingConfig",
     )
     cooldown_period = proto.Field(
-        proto.MESSAGE, number=2, message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=2,
+        message=duration_pb2.Duration,
     )
 
 
@@ -159,12 +176,26 @@ class BasicYarnAutoscalingConfig(proto.Message):
     """
 
     graceful_decommission_timeout = proto.Field(
-        proto.MESSAGE, number=5, message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=5,
+        message=duration_pb2.Duration,
     )
-    scale_up_factor = proto.Field(proto.DOUBLE, number=1,)
-    scale_down_factor = proto.Field(proto.DOUBLE, number=2,)
-    scale_up_min_worker_fraction = proto.Field(proto.DOUBLE, number=3,)
-    scale_down_min_worker_fraction = proto.Field(proto.DOUBLE, number=4,)
+    scale_up_factor = proto.Field(
+        proto.DOUBLE,
+        number=1,
+    )
+    scale_down_factor = proto.Field(
+        proto.DOUBLE,
+        number=2,
+    )
+    scale_up_min_worker_fraction = proto.Field(
+        proto.DOUBLE,
+        number=3,
+    )
+    scale_down_min_worker_fraction = proto.Field(
+        proto.DOUBLE,
+        number=4,
+    )
 
 
 class InstanceGroupAutoscalingPolicyConfig(proto.Message):
@@ -209,9 +240,18 @@ class InstanceGroupAutoscalingPolicyConfig(proto.Message):
             only and no secondary workers.
     """
 
-    min_instances = proto.Field(proto.INT32, number=1,)
-    max_instances = proto.Field(proto.INT32, number=2,)
-    weight = proto.Field(proto.INT32, number=3,)
+    min_instances = proto.Field(
+        proto.INT32,
+        number=1,
+    )
+    max_instances = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    weight = proto.Field(
+        proto.INT32,
+        number=3,
+    )
 
 
 class CreateAutoscalingPolicyRequest(proto.Message):
@@ -233,8 +273,15 @@ class CreateAutoscalingPolicyRequest(proto.Message):
             Required. The autoscaling policy to create.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    policy = proto.Field(proto.MESSAGE, number=2, message="AutoscalingPolicy",)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    policy = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="AutoscalingPolicy",
+    )
 
 
 class GetAutoscalingPolicyRequest(proto.Message):
@@ -254,7 +301,10 @@ class GetAutoscalingPolicyRequest(proto.Message):
                ``projects/{project_id}/locations/{location}/autoscalingPolicies/{policy_id}``
     """
 
-    name = proto.Field(proto.STRING, number=1,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class UpdateAutoscalingPolicyRequest(proto.Message):
@@ -264,7 +314,11 @@ class UpdateAutoscalingPolicyRequest(proto.Message):
             Required. The updated autoscaling policy.
     """
 
-    policy = proto.Field(proto.MESSAGE, number=1, message="AutoscalingPolicy",)
+    policy = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message="AutoscalingPolicy",
+    )
 
 
 class DeleteAutoscalingPolicyRequest(proto.Message):
@@ -287,7 +341,10 @@ class DeleteAutoscalingPolicyRequest(proto.Message):
                ``projects/{project_id}/locations/{location}/autoscalingPolicies/{policy_id}``
     """
 
-    name = proto.Field(proto.STRING, number=1,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class ListAutoscalingPoliciesRequest(proto.Message):
@@ -315,9 +372,18 @@ class ListAutoscalingPoliciesRequest(proto.Message):
             results.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    page_size = proto.Field(proto.INT32, number=2,)
-    page_token = proto.Field(proto.STRING, number=3,)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    page_size = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    page_token = proto.Field(
+        proto.STRING,
+        number=3,
+    )
 
 
 class ListAutoscalingPoliciesResponse(proto.Message):
@@ -337,9 +403,14 @@ class ListAutoscalingPoliciesResponse(proto.Message):
         return self
 
     policies = proto.RepeatedField(
-        proto.MESSAGE, number=1, message="AutoscalingPolicy",
+        proto.MESSAGE,
+        number=1,
+        message="AutoscalingPolicy",
     )
-    next_page_token = proto.Field(proto.STRING, number=2,)
+    next_page_token = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/dataproc_v1/types/clusters.py
+++ b/google/cloud/dataproc_v1/types/clusters.py
@@ -101,16 +101,43 @@ class Cluster(proto.Message):
             purposes only. It may be changed before final release.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    cluster_name = proto.Field(proto.STRING, number=2,)
-    config = proto.Field(proto.MESSAGE, number=3, message="ClusterConfig",)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=8,)
-    status = proto.Field(proto.MESSAGE, number=4, message="ClusterStatus",)
-    status_history = proto.RepeatedField(
-        proto.MESSAGE, number=7, message="ClusterStatus",
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
     )
-    cluster_uuid = proto.Field(proto.STRING, number=6,)
-    metrics = proto.Field(proto.MESSAGE, number=9, message="ClusterMetrics",)
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    config = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message="ClusterConfig",
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=8,
+    )
+    status = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message="ClusterStatus",
+    )
+    status_history = proto.RepeatedField(
+        proto.MESSAGE,
+        number=7,
+        message="ClusterStatus",
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=6,
+    )
+    metrics = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message="ClusterMetrics",
+    )
 
 
 class ClusterConfig(proto.Message):
@@ -195,34 +222,78 @@ class ClusterConfig(proto.Message):
             ``autoscaling_config``.
     """
 
-    config_bucket = proto.Field(proto.STRING, number=1,)
-    temp_bucket = proto.Field(proto.STRING, number=2,)
-    gce_cluster_config = proto.Field(
-        proto.MESSAGE, number=8, message="GceClusterConfig",
+    config_bucket = proto.Field(
+        proto.STRING,
+        number=1,
     )
-    master_config = proto.Field(proto.MESSAGE, number=9, message="InstanceGroupConfig",)
+    temp_bucket = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    gce_cluster_config = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message="GceClusterConfig",
+    )
+    master_config = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message="InstanceGroupConfig",
+    )
     worker_config = proto.Field(
-        proto.MESSAGE, number=10, message="InstanceGroupConfig",
+        proto.MESSAGE,
+        number=10,
+        message="InstanceGroupConfig",
     )
     secondary_worker_config = proto.Field(
-        proto.MESSAGE, number=12, message="InstanceGroupConfig",
+        proto.MESSAGE,
+        number=12,
+        message="InstanceGroupConfig",
     )
-    software_config = proto.Field(proto.MESSAGE, number=13, message="SoftwareConfig",)
+    software_config = proto.Field(
+        proto.MESSAGE,
+        number=13,
+        message="SoftwareConfig",
+    )
     initialization_actions = proto.RepeatedField(
-        proto.MESSAGE, number=11, message="NodeInitializationAction",
+        proto.MESSAGE,
+        number=11,
+        message="NodeInitializationAction",
     )
     encryption_config = proto.Field(
-        proto.MESSAGE, number=15, message="EncryptionConfig",
+        proto.MESSAGE,
+        number=15,
+        message="EncryptionConfig",
     )
     autoscaling_config = proto.Field(
-        proto.MESSAGE, number=18, message="AutoscalingConfig",
+        proto.MESSAGE,
+        number=18,
+        message="AutoscalingConfig",
     )
-    security_config = proto.Field(proto.MESSAGE, number=16, message="SecurityConfig",)
-    lifecycle_config = proto.Field(proto.MESSAGE, number=17, message="LifecycleConfig",)
-    endpoint_config = proto.Field(proto.MESSAGE, number=19, message="EndpointConfig",)
-    metastore_config = proto.Field(proto.MESSAGE, number=20, message="MetastoreConfig",)
+    security_config = proto.Field(
+        proto.MESSAGE,
+        number=16,
+        message="SecurityConfig",
+    )
+    lifecycle_config = proto.Field(
+        proto.MESSAGE,
+        number=17,
+        message="LifecycleConfig",
+    )
+    endpoint_config = proto.Field(
+        proto.MESSAGE,
+        number=19,
+        message="EndpointConfig",
+    )
+    metastore_config = proto.Field(
+        proto.MESSAGE,
+        number=20,
+        message="MetastoreConfig",
+    )
     gke_cluster_config = proto.Field(
-        proto.MESSAGE, number=21, message="GkeClusterConfig",
+        proto.MESSAGE,
+        number=21,
+        message="GkeClusterConfig",
     )
 
 
@@ -246,11 +317,19 @@ class GkeClusterConfig(proto.Message):
                 to deploy into.
         """
 
-        target_gke_cluster = proto.Field(proto.STRING, number=1,)
-        cluster_namespace = proto.Field(proto.STRING, number=2,)
+        target_gke_cluster = proto.Field(
+            proto.STRING,
+            number=1,
+        )
+        cluster_namespace = proto.Field(
+            proto.STRING,
+            number=2,
+        )
 
     namespaced_gke_deployment_target = proto.Field(
-        proto.MESSAGE, number=1, message=NamespacedGkeDeploymentTarget,
+        proto.MESSAGE,
+        number=1,
+        message=NamespacedGkeDeploymentTarget,
     )
 
 
@@ -266,8 +345,15 @@ class EndpointConfig(proto.Message):
             sources. Defaults to false.
     """
 
-    http_ports = proto.MapField(proto.STRING, proto.STRING, number=1,)
-    enable_http_port_access = proto.Field(proto.BOOL, number=2,)
+    http_ports = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=1,
+    )
+    enable_http_port_access = proto.Field(
+        proto.BOOL,
+        number=2,
+    )
 
 
 class AutoscalingConfig(proto.Message):
@@ -286,7 +372,10 @@ class AutoscalingConfig(proto.Message):
             Dataproc region.
     """
 
-    policy_uri = proto.Field(proto.STRING, number=1,)
+    policy_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class EncryptionConfig(proto.Message):
@@ -298,7 +387,10 @@ class EncryptionConfig(proto.Message):
             cluster.
     """
 
-    gce_pd_kms_key_name = proto.Field(proto.STRING, number=1,)
+    gce_pd_kms_key_name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class GceClusterConfig(proto.Message):
@@ -413,25 +505,58 @@ class GceClusterConfig(proto.Message):
         OUTBOUND = 2
         BIDIRECTIONAL = 3
 
-    zone_uri = proto.Field(proto.STRING, number=1,)
-    network_uri = proto.Field(proto.STRING, number=2,)
-    subnetwork_uri = proto.Field(proto.STRING, number=6,)
-    internal_ip_only = proto.Field(proto.BOOL, number=7,)
-    private_ipv6_google_access = proto.Field(
-        proto.ENUM, number=12, enum=PrivateIpv6GoogleAccess,
+    zone_uri = proto.Field(
+        proto.STRING,
+        number=1,
     )
-    service_account = proto.Field(proto.STRING, number=8,)
-    service_account_scopes = proto.RepeatedField(proto.STRING, number=3,)
-    tags = proto.RepeatedField(proto.STRING, number=4,)
-    metadata = proto.MapField(proto.STRING, proto.STRING, number=5,)
+    network_uri = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    subnetwork_uri = proto.Field(
+        proto.STRING,
+        number=6,
+    )
+    internal_ip_only = proto.Field(
+        proto.BOOL,
+        number=7,
+    )
+    private_ipv6_google_access = proto.Field(
+        proto.ENUM,
+        number=12,
+        enum=PrivateIpv6GoogleAccess,
+    )
+    service_account = proto.Field(
+        proto.STRING,
+        number=8,
+    )
+    service_account_scopes = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    tags = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    metadata = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=5,
+    )
     reservation_affinity = proto.Field(
-        proto.MESSAGE, number=11, message="ReservationAffinity",
+        proto.MESSAGE,
+        number=11,
+        message="ReservationAffinity",
     )
     node_group_affinity = proto.Field(
-        proto.MESSAGE, number=13, message="NodeGroupAffinity",
+        proto.MESSAGE,
+        number=13,
+        message="NodeGroupAffinity",
     )
     shielded_instance_config = proto.Field(
-        proto.MESSAGE, number=14, message="ShieldedInstanceConfig",
+        proto.MESSAGE,
+        number=14,
+        message="ShieldedInstanceConfig",
     )
 
 
@@ -453,7 +578,10 @@ class NodeGroupAffinity(proto.Message):
             -  ``node-group-1``
     """
 
-    node_group_uri = proto.Field(proto.STRING, number=1,)
+    node_group_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class ShieldedInstanceConfig(proto.Message):
@@ -472,9 +600,18 @@ class ShieldedInstanceConfig(proto.Message):
             integrity monitoring enabled.
     """
 
-    enable_secure_boot = proto.Field(proto.BOOL, number=1,)
-    enable_vtpm = proto.Field(proto.BOOL, number=2,)
-    enable_integrity_monitoring = proto.Field(proto.BOOL, number=3,)
+    enable_secure_boot = proto.Field(
+        proto.BOOL,
+        number=1,
+    )
+    enable_vtpm = proto.Field(
+        proto.BOOL,
+        number=2,
+    )
+    enable_integrity_monitoring = proto.Field(
+        proto.BOOL,
+        number=3,
+    )
 
 
 class InstanceGroupConfig(proto.Message):
@@ -566,20 +703,50 @@ class InstanceGroupConfig(proto.Message):
         NON_PREEMPTIBLE = 1
         PREEMPTIBLE = 2
 
-    num_instances = proto.Field(proto.INT32, number=1,)
-    instance_names = proto.RepeatedField(proto.STRING, number=2,)
-    image_uri = proto.Field(proto.STRING, number=3,)
-    machine_type_uri = proto.Field(proto.STRING, number=4,)
-    disk_config = proto.Field(proto.MESSAGE, number=5, message="DiskConfig",)
-    is_preemptible = proto.Field(proto.BOOL, number=6,)
-    preemptibility = proto.Field(proto.ENUM, number=10, enum=Preemptibility,)
+    num_instances = proto.Field(
+        proto.INT32,
+        number=1,
+    )
+    instance_names = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    image_uri = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    machine_type_uri = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    disk_config = proto.Field(
+        proto.MESSAGE,
+        number=5,
+        message="DiskConfig",
+    )
+    is_preemptible = proto.Field(
+        proto.BOOL,
+        number=6,
+    )
+    preemptibility = proto.Field(
+        proto.ENUM,
+        number=10,
+        enum=Preemptibility,
+    )
     managed_group_config = proto.Field(
-        proto.MESSAGE, number=7, message="ManagedGroupConfig",
+        proto.MESSAGE,
+        number=7,
+        message="ManagedGroupConfig",
     )
     accelerators = proto.RepeatedField(
-        proto.MESSAGE, number=8, message="AcceleratorConfig",
+        proto.MESSAGE,
+        number=8,
+        message="AcceleratorConfig",
     )
-    min_cpu_platform = proto.Field(proto.STRING, number=9,)
+    min_cpu_platform = proto.Field(
+        proto.STRING,
+        number=9,
+    )
 
 
 class ManagedGroupConfig(proto.Message):
@@ -595,8 +762,14 @@ class ManagedGroupConfig(proto.Message):
             Manager for this group.
     """
 
-    instance_template_name = proto.Field(proto.STRING, number=1,)
-    instance_group_manager_name = proto.Field(proto.STRING, number=2,)
+    instance_template_name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    instance_group_manager_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class AcceleratorConfig(proto.Message):
@@ -626,8 +799,14 @@ class AcceleratorConfig(proto.Message):
             type exposed to this instance.
     """
 
-    accelerator_type_uri = proto.Field(proto.STRING, number=1,)
-    accelerator_count = proto.Field(proto.INT32, number=2,)
+    accelerator_type_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    accelerator_count = proto.Field(
+        proto.INT32,
+        number=2,
+    )
 
 
 class DiskConfig(proto.Message):
@@ -655,9 +834,18 @@ class DiskConfig(proto.Message):
             basic config and installed binaries.
     """
 
-    boot_disk_type = proto.Field(proto.STRING, number=3,)
-    boot_disk_size_gb = proto.Field(proto.INT32, number=1,)
-    num_local_ssds = proto.Field(proto.INT32, number=2,)
+    boot_disk_type = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    boot_disk_size_gb = proto.Field(
+        proto.INT32,
+        number=1,
+    )
+    num_local_ssds = proto.Field(
+        proto.INT32,
+        number=2,
+    )
 
 
 class NodeInitializationAction(proto.Message):
@@ -679,9 +867,14 @@ class NodeInitializationAction(proto.Message):
             at end of the timeout period.
     """
 
-    executable_file = proto.Field(proto.STRING, number=1,)
+    executable_file = proto.Field(
+        proto.STRING,
+        number=1,
+    )
     execution_timeout = proto.Field(
-        proto.MESSAGE, number=2, message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=2,
+        message=duration_pb2.Duration,
     )
 
 
@@ -720,12 +913,25 @@ class ClusterStatus(proto.Message):
         UNHEALTHY = 1
         STALE_STATUS = 2
 
-    state = proto.Field(proto.ENUM, number=1, enum=State,)
-    detail = proto.Field(proto.STRING, number=2,)
-    state_start_time = proto.Field(
-        proto.MESSAGE, number=3, message=timestamp_pb2.Timestamp,
+    state = proto.Field(
+        proto.ENUM,
+        number=1,
+        enum=State,
     )
-    substate = proto.Field(proto.ENUM, number=4, enum=Substate,)
+    detail = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    state_start_time = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message=timestamp_pb2.Timestamp,
+    )
+    substate = proto.Field(
+        proto.ENUM,
+        number=4,
+        enum=Substate,
+    )
 
 
 class SecurityConfig(proto.Message):
@@ -741,8 +947,16 @@ class SecurityConfig(proto.Message):
             tenancy user mappings.
     """
 
-    kerberos_config = proto.Field(proto.MESSAGE, number=1, message="KerberosConfig",)
-    identity_config = proto.Field(proto.MESSAGE, number=2, message="IdentityConfig",)
+    kerberos_config = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message="KerberosConfig",
+    )
+    identity_config = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="IdentityConfig",
+    )
 
 
 class KerberosConfig(proto.Message):
@@ -819,21 +1033,66 @@ class KerberosConfig(proto.Message):
             of hostnames will be the realm.
     """
 
-    enable_kerberos = proto.Field(proto.BOOL, number=1,)
-    root_principal_password_uri = proto.Field(proto.STRING, number=2,)
-    kms_key_uri = proto.Field(proto.STRING, number=3,)
-    keystore_uri = proto.Field(proto.STRING, number=4,)
-    truststore_uri = proto.Field(proto.STRING, number=5,)
-    keystore_password_uri = proto.Field(proto.STRING, number=6,)
-    key_password_uri = proto.Field(proto.STRING, number=7,)
-    truststore_password_uri = proto.Field(proto.STRING, number=8,)
-    cross_realm_trust_realm = proto.Field(proto.STRING, number=9,)
-    cross_realm_trust_kdc = proto.Field(proto.STRING, number=10,)
-    cross_realm_trust_admin_server = proto.Field(proto.STRING, number=11,)
-    cross_realm_trust_shared_password_uri = proto.Field(proto.STRING, number=12,)
-    kdc_db_key_uri = proto.Field(proto.STRING, number=13,)
-    tgt_lifetime_hours = proto.Field(proto.INT32, number=14,)
-    realm = proto.Field(proto.STRING, number=15,)
+    enable_kerberos = proto.Field(
+        proto.BOOL,
+        number=1,
+    )
+    root_principal_password_uri = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    kms_key_uri = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    keystore_uri = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    truststore_uri = proto.Field(
+        proto.STRING,
+        number=5,
+    )
+    keystore_password_uri = proto.Field(
+        proto.STRING,
+        number=6,
+    )
+    key_password_uri = proto.Field(
+        proto.STRING,
+        number=7,
+    )
+    truststore_password_uri = proto.Field(
+        proto.STRING,
+        number=8,
+    )
+    cross_realm_trust_realm = proto.Field(
+        proto.STRING,
+        number=9,
+    )
+    cross_realm_trust_kdc = proto.Field(
+        proto.STRING,
+        number=10,
+    )
+    cross_realm_trust_admin_server = proto.Field(
+        proto.STRING,
+        number=11,
+    )
+    cross_realm_trust_shared_password_uri = proto.Field(
+        proto.STRING,
+        number=12,
+    )
+    kdc_db_key_uri = proto.Field(
+        proto.STRING,
+        number=13,
+    )
+    tgt_lifetime_hours = proto.Field(
+        proto.INT32,
+        number=14,
+    )
+    realm = proto.Field(
+        proto.STRING,
+        number=15,
+    )
 
 
 class IdentityConfig(proto.Message):
@@ -845,7 +1104,11 @@ class IdentityConfig(proto.Message):
             Required. Map of user to service account.
     """
 
-    user_service_account_mapping = proto.MapField(proto.STRING, proto.STRING, number=1,)
+    user_service_account_mapping = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=1,
+    )
 
 
 class SoftwareConfig(proto.Message):
@@ -885,10 +1148,19 @@ class SoftwareConfig(proto.Message):
             on the cluster.
     """
 
-    image_version = proto.Field(proto.STRING, number=1,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=2,)
+    image_version = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=2,
+    )
     optional_components = proto.RepeatedField(
-        proto.ENUM, number=3, enum=shared.Component,
+        proto.ENUM,
+        number=3,
+        enum=shared.Component,
     )
 
 
@@ -920,16 +1192,26 @@ class LifecycleConfig(proto.Message):
     """
 
     idle_delete_ttl = proto.Field(
-        proto.MESSAGE, number=1, message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=1,
+        message=duration_pb2.Duration,
     )
     auto_delete_time = proto.Field(
-        proto.MESSAGE, number=2, oneof="ttl", message=timestamp_pb2.Timestamp,
+        proto.MESSAGE,
+        number=2,
+        oneof="ttl",
+        message=timestamp_pb2.Timestamp,
     )
     auto_delete_ttl = proto.Field(
-        proto.MESSAGE, number=3, oneof="ttl", message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=3,
+        oneof="ttl",
+        message=duration_pb2.Duration,
     )
     idle_start_time = proto.Field(
-        proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,
+        proto.MESSAGE,
+        number=4,
+        message=timestamp_pb2.Timestamp,
     )
 
 
@@ -945,7 +1227,10 @@ class MetastoreConfig(proto.Message):
             -  ``projects/[project_id]/locations/[dataproc_region]/services/[service-name]``
     """
 
-    dataproc_metastore_service = proto.Field(proto.STRING, number=1,)
+    dataproc_metastore_service = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class ClusterMetrics(proto.Message):
@@ -961,8 +1246,16 @@ class ClusterMetrics(proto.Message):
             The YARN metrics.
     """
 
-    hdfs_metrics = proto.MapField(proto.STRING, proto.INT64, number=1,)
-    yarn_metrics = proto.MapField(proto.STRING, proto.INT64, number=2,)
+    hdfs_metrics = proto.MapField(
+        proto.STRING,
+        proto.INT64,
+        number=1,
+    )
+    yarn_metrics = proto.MapField(
+        proto.STRING,
+        proto.INT64,
+        number=2,
+    )
 
 
 class CreateClusterRequest(proto.Message):
@@ -993,10 +1286,23 @@ class CreateClusterRequest(proto.Message):
             characters.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    cluster = proto.Field(proto.MESSAGE, number=2, message="Cluster",)
-    request_id = proto.Field(proto.STRING, number=4,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="Cluster",
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=4,
+    )
 
 
 class UpdateClusterRequest(proto.Message):
@@ -1102,17 +1408,37 @@ class UpdateClusterRequest(proto.Message):
             characters.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=5,)
-    cluster_name = proto.Field(proto.STRING, number=2,)
-    cluster = proto.Field(proto.MESSAGE, number=3, message="Cluster",)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=5,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    cluster = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message="Cluster",
+    )
     graceful_decommission_timeout = proto.Field(
-        proto.MESSAGE, number=6, message=duration_pb2.Duration,
+        proto.MESSAGE,
+        number=6,
+        message=duration_pb2.Duration,
     )
     update_mask = proto.Field(
-        proto.MESSAGE, number=4, message=field_mask_pb2.FieldMask,
+        proto.MESSAGE,
+        number=4,
+        message=field_mask_pb2.FieldMask,
     )
-    request_id = proto.Field(proto.STRING, number=7,)
+    request_id = proto.Field(
+        proto.STRING,
+        number=7,
+    )
 
 
 class StopClusterRequest(proto.Message):
@@ -1147,11 +1473,26 @@ class StopClusterRequest(proto.Message):
             characters.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=2,)
-    cluster_name = proto.Field(proto.STRING, number=3,)
-    cluster_uuid = proto.Field(proto.STRING, number=4,)
-    request_id = proto.Field(proto.STRING, number=5,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=5,
+    )
 
 
 class StartClusterRequest(proto.Message):
@@ -1186,11 +1527,26 @@ class StartClusterRequest(proto.Message):
             characters.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=2,)
-    cluster_name = proto.Field(proto.STRING, number=3,)
-    cluster_uuid = proto.Field(proto.STRING, number=4,)
-    request_id = proto.Field(proto.STRING, number=5,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=5,
+    )
 
 
 class DeleteClusterRequest(proto.Message):
@@ -1225,11 +1581,26 @@ class DeleteClusterRequest(proto.Message):
             characters.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    cluster_name = proto.Field(proto.STRING, number=2,)
-    cluster_uuid = proto.Field(proto.STRING, number=4,)
-    request_id = proto.Field(proto.STRING, number=5,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=5,
+    )
 
 
 class GetClusterRequest(proto.Message):
@@ -1247,9 +1618,18 @@ class GetClusterRequest(proto.Message):
             Required. The cluster name.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    cluster_name = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class ListClustersRequest(proto.Message):
@@ -1289,11 +1669,26 @@ class ListClustersRequest(proto.Message):
             Optional. The standard List page token.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=4,)
-    filter = proto.Field(proto.STRING, number=5,)
-    page_size = proto.Field(proto.INT32, number=2,)
-    page_token = proto.Field(proto.STRING, number=3,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    filter = proto.Field(
+        proto.STRING,
+        number=5,
+    )
+    page_size = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    page_token = proto.Field(
+        proto.STRING,
+        number=3,
+    )
 
 
 class ListClustersResponse(proto.Message):
@@ -1312,8 +1707,15 @@ class ListClustersResponse(proto.Message):
     def raw_page(self):
         return self
 
-    clusters = proto.RepeatedField(proto.MESSAGE, number=1, message="Cluster",)
-    next_page_token = proto.Field(proto.STRING, number=2,)
+    clusters = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message="Cluster",
+    )
+    next_page_token = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class DiagnoseClusterRequest(proto.Message):
@@ -1329,9 +1731,18 @@ class DiagnoseClusterRequest(proto.Message):
             Required. The cluster name.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    cluster_name = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class DiagnoseClusterResults(proto.Message):
@@ -1344,7 +1755,10 @@ class DiagnoseClusterResults(proto.Message):
             diagnostics.
     """
 
-    output_uri = proto.Field(proto.STRING, number=1,)
+    output_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
 
 
 class ReservationAffinity(proto.Message):
@@ -1369,9 +1783,19 @@ class ReservationAffinity(proto.Message):
         ANY_RESERVATION = 2
         SPECIFIC_RESERVATION = 3
 
-    consume_reservation_type = proto.Field(proto.ENUM, number=1, enum=Type,)
-    key = proto.Field(proto.STRING, number=2,)
-    values = proto.RepeatedField(proto.STRING, number=3,)
+    consume_reservation_type = proto.Field(
+        proto.ENUM,
+        number=1,
+        enum=Type,
+    )
+    key = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    values = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/dataproc_v1/types/jobs.py
+++ b/google/cloud/dataproc_v1/types/jobs.py
@@ -76,7 +76,12 @@ class LoggingConfig(proto.Message):
         FATAL = 7
         OFF = 8
 
-    driver_log_levels = proto.MapField(proto.STRING, proto.ENUM, number=2, enum=Level,)
+    driver_log_levels = proto.MapField(
+        proto.STRING,
+        proto.ENUM,
+        number=2,
+        enum=Level,
+    )
 
 
 class HadoopJob(proto.Message):
@@ -127,14 +132,42 @@ class HadoopJob(proto.Message):
             execution.
     """
 
-    main_jar_file_uri = proto.Field(proto.STRING, number=1, oneof="driver",)
-    main_class = proto.Field(proto.STRING, number=2, oneof="driver",)
-    args = proto.RepeatedField(proto.STRING, number=3,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=4,)
-    file_uris = proto.RepeatedField(proto.STRING, number=5,)
-    archive_uris = proto.RepeatedField(proto.STRING, number=6,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=7,)
-    logging_config = proto.Field(proto.MESSAGE, number=8, message="LoggingConfig",)
+    main_jar_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="driver",
+    )
+    main_class = proto.Field(
+        proto.STRING,
+        number=2,
+        oneof="driver",
+    )
+    args = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=5,
+    )
+    archive_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=7,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message="LoggingConfig",
+    )
 
 
 class SparkJob(proto.Message):
@@ -178,14 +211,42 @@ class SparkJob(proto.Message):
             execution.
     """
 
-    main_jar_file_uri = proto.Field(proto.STRING, number=1, oneof="driver",)
-    main_class = proto.Field(proto.STRING, number=2, oneof="driver",)
-    args = proto.RepeatedField(proto.STRING, number=3,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=4,)
-    file_uris = proto.RepeatedField(proto.STRING, number=5,)
-    archive_uris = proto.RepeatedField(proto.STRING, number=6,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=7,)
-    logging_config = proto.Field(proto.MESSAGE, number=8, message="LoggingConfig",)
+    main_jar_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="driver",
+    )
+    main_class = proto.Field(
+        proto.STRING,
+        number=2,
+        oneof="driver",
+    )
+    args = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=5,
+    )
+    archive_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=7,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message="LoggingConfig",
+    )
 
 
 class PySparkJob(proto.Message):
@@ -231,14 +292,40 @@ class PySparkJob(proto.Message):
             execution.
     """
 
-    main_python_file_uri = proto.Field(proto.STRING, number=1,)
-    args = proto.RepeatedField(proto.STRING, number=2,)
-    python_file_uris = proto.RepeatedField(proto.STRING, number=3,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=4,)
-    file_uris = proto.RepeatedField(proto.STRING, number=5,)
-    archive_uris = proto.RepeatedField(proto.STRING, number=6,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=7,)
-    logging_config = proto.Field(proto.MESSAGE, number=8, message="LoggingConfig",)
+    main_python_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    args = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    python_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=5,
+    )
+    archive_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=7,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message="LoggingConfig",
+    )
 
 
 class QueryList(proto.Message):
@@ -264,7 +351,10 @@ class QueryList(proto.Message):
                 }
     """
 
-    queries = proto.RepeatedField(proto.STRING, number=1,)
+    queries = proto.RepeatedField(
+        proto.STRING,
+        number=1,
+    )
 
 
 class HiveJob(proto.Message):
@@ -297,14 +387,35 @@ class HiveJob(proto.Message):
             and UDFs.
     """
 
-    query_file_uri = proto.Field(proto.STRING, number=1, oneof="queries",)
-    query_list = proto.Field(
-        proto.MESSAGE, number=2, oneof="queries", message="QueryList",
+    query_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="queries",
     )
-    continue_on_failure = proto.Field(proto.BOOL, number=3,)
-    script_variables = proto.MapField(proto.STRING, proto.STRING, number=4,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=5,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=6,)
+    query_list = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        oneof="queries",
+        message="QueryList",
+    )
+    continue_on_failure = proto.Field(
+        proto.BOOL,
+        number=3,
+    )
+    script_variables = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=4,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=5,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
 
 
 class SparkSqlJob(proto.Message):
@@ -334,14 +445,36 @@ class SparkSqlJob(proto.Message):
             execution.
     """
 
-    query_file_uri = proto.Field(proto.STRING, number=1, oneof="queries",)
-    query_list = proto.Field(
-        proto.MESSAGE, number=2, oneof="queries", message="QueryList",
+    query_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="queries",
     )
-    script_variables = proto.MapField(proto.STRING, proto.STRING, number=3,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=4,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=56,)
-    logging_config = proto.Field(proto.MESSAGE, number=6, message="LoggingConfig",)
+    query_list = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        oneof="queries",
+        message="QueryList",
+    )
+    script_variables = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=3,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=4,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=56,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=6,
+        message="LoggingConfig",
+    )
 
 
 class PigJob(proto.Message):
@@ -376,15 +509,40 @@ class PigJob(proto.Message):
             execution.
     """
 
-    query_file_uri = proto.Field(proto.STRING, number=1, oneof="queries",)
-    query_list = proto.Field(
-        proto.MESSAGE, number=2, oneof="queries", message="QueryList",
+    query_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="queries",
     )
-    continue_on_failure = proto.Field(proto.BOOL, number=3,)
-    script_variables = proto.MapField(proto.STRING, proto.STRING, number=4,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=5,)
-    jar_file_uris = proto.RepeatedField(proto.STRING, number=6,)
-    logging_config = proto.Field(proto.MESSAGE, number=7, message="LoggingConfig",)
+    query_list = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        oneof="queries",
+        message="QueryList",
+    )
+    continue_on_failure = proto.Field(
+        proto.BOOL,
+        number=3,
+    )
+    script_variables = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=4,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=5,
+    )
+    jar_file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=6,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=7,
+        message="LoggingConfig",
+    )
 
 
 class SparkRJob(proto.Message):
@@ -423,12 +581,32 @@ class SparkRJob(proto.Message):
             execution.
     """
 
-    main_r_file_uri = proto.Field(proto.STRING, number=1,)
-    args = proto.RepeatedField(proto.STRING, number=2,)
-    file_uris = proto.RepeatedField(proto.STRING, number=3,)
-    archive_uris = proto.RepeatedField(proto.STRING, number=4,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=5,)
-    logging_config = proto.Field(proto.MESSAGE, number=6, message="LoggingConfig",)
+    main_r_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    args = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    file_uris = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    archive_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=5,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=6,
+        message="LoggingConfig",
+    )
 
 
 class PrestoJob(proto.Message):
@@ -465,15 +643,39 @@ class PrestoJob(proto.Message):
             execution.
     """
 
-    query_file_uri = proto.Field(proto.STRING, number=1, oneof="queries",)
-    query_list = proto.Field(
-        proto.MESSAGE, number=2, oneof="queries", message="QueryList",
+    query_file_uri = proto.Field(
+        proto.STRING,
+        number=1,
+        oneof="queries",
     )
-    continue_on_failure = proto.Field(proto.BOOL, number=3,)
-    output_format = proto.Field(proto.STRING, number=4,)
-    client_tags = proto.RepeatedField(proto.STRING, number=5,)
-    properties = proto.MapField(proto.STRING, proto.STRING, number=6,)
-    logging_config = proto.Field(proto.MESSAGE, number=7, message="LoggingConfig",)
+    query_list = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        oneof="queries",
+        message="QueryList",
+    )
+    continue_on_failure = proto.Field(
+        proto.BOOL,
+        number=3,
+    )
+    output_format = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    client_tags = proto.RepeatedField(
+        proto.STRING,
+        number=5,
+    )
+    properties = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=6,
+    )
+    logging_config = proto.Field(
+        proto.MESSAGE,
+        number=7,
+        message="LoggingConfig",
+    )
 
 
 class JobPlacement(proto.Message):
@@ -490,9 +692,19 @@ class JobPlacement(proto.Message):
             cluster where the job will be submitted.
     """
 
-    cluster_name = proto.Field(proto.STRING, number=1,)
-    cluster_uuid = proto.Field(proto.STRING, number=2,)
-    cluster_labels = proto.MapField(proto.STRING, proto.STRING, number=3,)
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    cluster_labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=3,
+    )
 
 
 class JobStatus(proto.Message):
@@ -533,12 +745,25 @@ class JobStatus(proto.Message):
         QUEUED = 2
         STALE_STATUS = 3
 
-    state = proto.Field(proto.ENUM, number=1, enum=State,)
-    details = proto.Field(proto.STRING, number=2,)
-    state_start_time = proto.Field(
-        proto.MESSAGE, number=6, message=timestamp_pb2.Timestamp,
+    state = proto.Field(
+        proto.ENUM,
+        number=1,
+        enum=State,
     )
-    substate = proto.Field(proto.ENUM, number=7, enum=Substate,)
+    details = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    state_start_time = proto.Field(
+        proto.MESSAGE,
+        number=6,
+        message=timestamp_pb2.Timestamp,
+    )
+    substate = proto.Field(
+        proto.ENUM,
+        number=7,
+        enum=Substate,
+    )
 
 
 class JobReference(proto.Message):
@@ -560,8 +785,14 @@ class JobReference(proto.Message):
             by the server.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    job_id = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class YarnApplication(proto.Message):
@@ -603,10 +834,23 @@ class YarnApplication(proto.Message):
         FAILED = 7
         KILLED = 8
 
-    name = proto.Field(proto.STRING, number=1,)
-    state = proto.Field(proto.ENUM, number=2, enum=State,)
-    progress = proto.Field(proto.FLOAT, number=3,)
-    tracking_url = proto.Field(proto.STRING, number=4,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    state = proto.Field(
+        proto.ENUM,
+        number=2,
+        enum=State,
+    )
+    progress = proto.Field(
+        proto.FLOAT,
+        number=3,
+    )
+    tracking_url = proto.Field(
+        proto.STRING,
+        number=4,
+    )
 
 
 class Job(proto.Message):
@@ -677,41 +921,105 @@ class Job(proto.Message):
             will indicate if it was successful, failed, or cancelled.
     """
 
-    reference = proto.Field(proto.MESSAGE, number=1, message="JobReference",)
-    placement = proto.Field(proto.MESSAGE, number=2, message="JobPlacement",)
+    reference = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message="JobReference",
+    )
+    placement = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="JobPlacement",
+    )
     hadoop_job = proto.Field(
-        proto.MESSAGE, number=3, oneof="type_job", message="HadoopJob",
+        proto.MESSAGE,
+        number=3,
+        oneof="type_job",
+        message="HadoopJob",
     )
     spark_job = proto.Field(
-        proto.MESSAGE, number=4, oneof="type_job", message="SparkJob",
+        proto.MESSAGE,
+        number=4,
+        oneof="type_job",
+        message="SparkJob",
     )
     pyspark_job = proto.Field(
-        proto.MESSAGE, number=5, oneof="type_job", message="PySparkJob",
+        proto.MESSAGE,
+        number=5,
+        oneof="type_job",
+        message="PySparkJob",
     )
     hive_job = proto.Field(
-        proto.MESSAGE, number=6, oneof="type_job", message="HiveJob",
+        proto.MESSAGE,
+        number=6,
+        oneof="type_job",
+        message="HiveJob",
     )
-    pig_job = proto.Field(proto.MESSAGE, number=7, oneof="type_job", message="PigJob",)
+    pig_job = proto.Field(
+        proto.MESSAGE,
+        number=7,
+        oneof="type_job",
+        message="PigJob",
+    )
     spark_r_job = proto.Field(
-        proto.MESSAGE, number=21, oneof="type_job", message="SparkRJob",
+        proto.MESSAGE,
+        number=21,
+        oneof="type_job",
+        message="SparkRJob",
     )
     spark_sql_job = proto.Field(
-        proto.MESSAGE, number=12, oneof="type_job", message="SparkSqlJob",
+        proto.MESSAGE,
+        number=12,
+        oneof="type_job",
+        message="SparkSqlJob",
     )
     presto_job = proto.Field(
-        proto.MESSAGE, number=23, oneof="type_job", message="PrestoJob",
+        proto.MESSAGE,
+        number=23,
+        oneof="type_job",
+        message="PrestoJob",
     )
-    status = proto.Field(proto.MESSAGE, number=8, message="JobStatus",)
-    status_history = proto.RepeatedField(proto.MESSAGE, number=13, message="JobStatus",)
+    status = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message="JobStatus",
+    )
+    status_history = proto.RepeatedField(
+        proto.MESSAGE,
+        number=13,
+        message="JobStatus",
+    )
     yarn_applications = proto.RepeatedField(
-        proto.MESSAGE, number=9, message="YarnApplication",
+        proto.MESSAGE,
+        number=9,
+        message="YarnApplication",
     )
-    driver_output_resource_uri = proto.Field(proto.STRING, number=17,)
-    driver_control_files_uri = proto.Field(proto.STRING, number=15,)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=18,)
-    scheduling = proto.Field(proto.MESSAGE, number=20, message="JobScheduling",)
-    job_uuid = proto.Field(proto.STRING, number=22,)
-    done = proto.Field(proto.BOOL, number=24,)
+    driver_output_resource_uri = proto.Field(
+        proto.STRING,
+        number=17,
+    )
+    driver_control_files_uri = proto.Field(
+        proto.STRING,
+        number=15,
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=18,
+    )
+    scheduling = proto.Field(
+        proto.MESSAGE,
+        number=20,
+        message="JobScheduling",
+    )
+    job_uuid = proto.Field(
+        proto.STRING,
+        number=22,
+    )
+    done = proto.Field(
+        proto.BOOL,
+        number=24,
+    )
 
 
 class JobScheduling(proto.Message):
@@ -735,8 +1043,14 @@ class JobScheduling(proto.Message):
             reported failed. Maximum value is 240.
     """
 
-    max_failures_per_hour = proto.Field(proto.INT32, number=1,)
-    max_failures_total = proto.Field(proto.INT32, number=2,)
+    max_failures_per_hour = proto.Field(
+        proto.INT32,
+        number=1,
+    )
+    max_failures_total = proto.Field(
+        proto.INT32,
+        number=2,
+    )
 
 
 class SubmitJobRequest(proto.Message):
@@ -766,10 +1080,23 @@ class SubmitJobRequest(proto.Message):
             characters.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    job = proto.Field(proto.MESSAGE, number=2, message="Job",)
-    request_id = proto.Field(proto.STRING, number=4,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    job = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="Job",
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=4,
+    )
 
 
 class JobMetadata(proto.Message):
@@ -785,10 +1112,24 @@ class JobMetadata(proto.Message):
             Output only. Job submission time.
     """
 
-    job_id = proto.Field(proto.STRING, number=1,)
-    status = proto.Field(proto.MESSAGE, number=2, message="JobStatus",)
-    operation_type = proto.Field(proto.STRING, number=3,)
-    start_time = proto.Field(proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,)
+    job_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    status = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="JobStatus",
+    )
+    operation_type = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    start_time = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message=timestamp_pb2.Timestamp,
+    )
 
 
 class GetJobRequest(proto.Message):
@@ -806,9 +1147,18 @@ class GetJobRequest(proto.Message):
             Required. The job ID.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    job_id = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class ListJobsRequest(proto.Message):
@@ -862,13 +1212,35 @@ class ListJobsRequest(proto.Message):
         ACTIVE = 1
         NON_ACTIVE = 2
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=6,)
-    page_size = proto.Field(proto.INT32, number=2,)
-    page_token = proto.Field(proto.STRING, number=3,)
-    cluster_name = proto.Field(proto.STRING, number=4,)
-    job_state_matcher = proto.Field(proto.ENUM, number=5, enum=JobStateMatcher,)
-    filter = proto.Field(proto.STRING, number=7,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=6,
+    )
+    page_size = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    page_token = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    job_state_matcher = proto.Field(
+        proto.ENUM,
+        number=5,
+        enum=JobStateMatcher,
+    )
+    filter = proto.Field(
+        proto.STRING,
+        number=7,
+    )
 
 
 class UpdateJobRequest(proto.Message):
@@ -892,12 +1264,27 @@ class UpdateJobRequest(proto.Message):
             Currently, labels is the only field that can be updated.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=2,)
-    job_id = proto.Field(proto.STRING, number=3,)
-    job = proto.Field(proto.MESSAGE, number=4, message="Job",)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    job = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message="Job",
+    )
     update_mask = proto.Field(
-        proto.MESSAGE, number=5, message=field_mask_pb2.FieldMask,
+        proto.MESSAGE,
+        number=5,
+        message=field_mask_pb2.FieldMask,
     )
 
 
@@ -917,8 +1304,15 @@ class ListJobsResponse(proto.Message):
     def raw_page(self):
         return self
 
-    jobs = proto.RepeatedField(proto.MESSAGE, number=1, message="Job",)
-    next_page_token = proto.Field(proto.STRING, number=2,)
+    jobs = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message="Job",
+    )
+    next_page_token = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class CancelJobRequest(proto.Message):
@@ -934,9 +1328,18 @@ class CancelJobRequest(proto.Message):
             Required. The job ID.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    job_id = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class DeleteJobRequest(proto.Message):
@@ -952,9 +1355,18 @@ class DeleteJobRequest(proto.Message):
             Required. The job ID.
     """
 
-    project_id = proto.Field(proto.STRING, number=1,)
-    region = proto.Field(proto.STRING, number=3,)
-    job_id = proto.Field(proto.STRING, number=2,)
+    project_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    region = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/dataproc_v1/types/operations.py
+++ b/google/cloud/dataproc_v1/types/operations.py
@@ -20,7 +20,10 @@ from google.protobuf import timestamp_pb2  # type: ignore
 
 __protobuf__ = proto.module(
     package="google.cloud.dataproc.v1",
-    manifest={"ClusterOperationStatus", "ClusterOperationMetadata",},
+    manifest={
+        "ClusterOperationStatus",
+        "ClusterOperationMetadata",
+    },
 )
 
 
@@ -47,11 +50,23 @@ class ClusterOperationStatus(proto.Message):
         RUNNING = 2
         DONE = 3
 
-    state = proto.Field(proto.ENUM, number=1, enum=State,)
-    inner_state = proto.Field(proto.STRING, number=2,)
-    details = proto.Field(proto.STRING, number=3,)
+    state = proto.Field(
+        proto.ENUM,
+        number=1,
+        enum=State,
+    )
+    inner_state = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    details = proto.Field(
+        proto.STRING,
+        number=3,
+    )
     state_start_time = proto.Field(
-        proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,
+        proto.MESSAGE,
+        number=4,
+        message=timestamp_pb2.Timestamp,
     )
 
 
@@ -79,16 +94,41 @@ class ClusterOperationMetadata(proto.Message):
             operation execution.
     """
 
-    cluster_name = proto.Field(proto.STRING, number=7,)
-    cluster_uuid = proto.Field(proto.STRING, number=8,)
-    status = proto.Field(proto.MESSAGE, number=9, message="ClusterOperationStatus",)
-    status_history = proto.RepeatedField(
-        proto.MESSAGE, number=10, message="ClusterOperationStatus",
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=7,
     )
-    operation_type = proto.Field(proto.STRING, number=11,)
-    description = proto.Field(proto.STRING, number=12,)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=13,)
-    warnings = proto.RepeatedField(proto.STRING, number=14,)
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=8,
+    )
+    status = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message="ClusterOperationStatus",
+    )
+    status_history = proto.RepeatedField(
+        proto.MESSAGE,
+        number=10,
+        message="ClusterOperationStatus",
+    )
+    operation_type = proto.Field(
+        proto.STRING,
+        number=11,
+    )
+    description = proto.Field(
+        proto.STRING,
+        number=12,
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=13,
+    )
+    warnings = proto.RepeatedField(
+        proto.STRING,
+        number=14,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/dataproc_v1/types/shared.py
+++ b/google/cloud/dataproc_v1/types/shared.py
@@ -17,7 +17,10 @@ import proto  # type: ignore
 
 
 __protobuf__ = proto.module(
-    package="google.cloud.dataproc.v1", manifest={"Component",},
+    package="google.cloud.dataproc.v1",
+    manifest={
+        "Component",
+    },
 )
 
 

--- a/google/cloud/dataproc_v1/types/workflow_templates.py
+++ b/google/cloud/dataproc_v1/types/workflow_templates.py
@@ -122,20 +122,53 @@ class WorkflowTemplate(proto.Message):
             the cluster is deleted.
     """
 
-    id = proto.Field(proto.STRING, number=2,)
-    name = proto.Field(proto.STRING, number=1,)
-    version = proto.Field(proto.INT32, number=3,)
-    create_time = proto.Field(proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp,)
-    update_time = proto.Field(proto.MESSAGE, number=5, message=timestamp_pb2.Timestamp,)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=6,)
+    id = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    version = proto.Field(
+        proto.INT32,
+        number=3,
+    )
+    create_time = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message=timestamp_pb2.Timestamp,
+    )
+    update_time = proto.Field(
+        proto.MESSAGE,
+        number=5,
+        message=timestamp_pb2.Timestamp,
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=6,
+    )
     placement = proto.Field(
-        proto.MESSAGE, number=7, message="WorkflowTemplatePlacement",
+        proto.MESSAGE,
+        number=7,
+        message="WorkflowTemplatePlacement",
     )
-    jobs = proto.RepeatedField(proto.MESSAGE, number=8, message="OrderedJob",)
+    jobs = proto.RepeatedField(
+        proto.MESSAGE,
+        number=8,
+        message="OrderedJob",
+    )
     parameters = proto.RepeatedField(
-        proto.MESSAGE, number=9, message="TemplateParameter",
+        proto.MESSAGE,
+        number=9,
+        message="TemplateParameter",
     )
-    dag_timeout = proto.Field(proto.MESSAGE, number=10, message=duration_pb2.Duration,)
+    dag_timeout = proto.Field(
+        proto.MESSAGE,
+        number=10,
+        message=duration_pb2.Duration,
+    )
 
 
 class WorkflowTemplatePlacement(proto.Message):
@@ -155,10 +188,16 @@ class WorkflowTemplatePlacement(proto.Message):
     """
 
     managed_cluster = proto.Field(
-        proto.MESSAGE, number=1, oneof="placement", message="ManagedCluster",
+        proto.MESSAGE,
+        number=1,
+        oneof="placement",
+        message="ManagedCluster",
     )
     cluster_selector = proto.Field(
-        proto.MESSAGE, number=2, oneof="placement", message="ClusterSelector",
+        proto.MESSAGE,
+        number=2,
+        oneof="placement",
+        message="ClusterSelector",
     )
 
 
@@ -191,9 +230,20 @@ class ManagedCluster(proto.Message):
             cluster.
     """
 
-    cluster_name = proto.Field(proto.STRING, number=2,)
-    config = proto.Field(proto.MESSAGE, number=3, message=clusters.ClusterConfig,)
-    labels = proto.MapField(proto.STRING, proto.STRING, number=4,)
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    config = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message=clusters.ClusterConfig,
+    )
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=4,
+    )
 
 
 class ClusterSelector(proto.Message):
@@ -212,8 +262,15 @@ class ClusterSelector(proto.Message):
             have all labels to match.
     """
 
-    zone = proto.Field(proto.STRING, number=1,)
-    cluster_labels = proto.MapField(proto.STRING, proto.STRING, number=2,)
+    zone = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    cluster_labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=2,
+    )
 
 
 class OrderedJob(proto.Message):
@@ -268,34 +325,72 @@ class OrderedJob(proto.Message):
             workflow.
     """
 
-    step_id = proto.Field(proto.STRING, number=1,)
+    step_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
     hadoop_job = proto.Field(
-        proto.MESSAGE, number=2, oneof="job_type", message=gcd_jobs.HadoopJob,
+        proto.MESSAGE,
+        number=2,
+        oneof="job_type",
+        message=gcd_jobs.HadoopJob,
     )
     spark_job = proto.Field(
-        proto.MESSAGE, number=3, oneof="job_type", message=gcd_jobs.SparkJob,
+        proto.MESSAGE,
+        number=3,
+        oneof="job_type",
+        message=gcd_jobs.SparkJob,
     )
     pyspark_job = proto.Field(
-        proto.MESSAGE, number=4, oneof="job_type", message=gcd_jobs.PySparkJob,
+        proto.MESSAGE,
+        number=4,
+        oneof="job_type",
+        message=gcd_jobs.PySparkJob,
     )
     hive_job = proto.Field(
-        proto.MESSAGE, number=5, oneof="job_type", message=gcd_jobs.HiveJob,
+        proto.MESSAGE,
+        number=5,
+        oneof="job_type",
+        message=gcd_jobs.HiveJob,
     )
     pig_job = proto.Field(
-        proto.MESSAGE, number=6, oneof="job_type", message=gcd_jobs.PigJob,
+        proto.MESSAGE,
+        number=6,
+        oneof="job_type",
+        message=gcd_jobs.PigJob,
     )
     spark_r_job = proto.Field(
-        proto.MESSAGE, number=11, oneof="job_type", message=gcd_jobs.SparkRJob,
+        proto.MESSAGE,
+        number=11,
+        oneof="job_type",
+        message=gcd_jobs.SparkRJob,
     )
     spark_sql_job = proto.Field(
-        proto.MESSAGE, number=7, oneof="job_type", message=gcd_jobs.SparkSqlJob,
+        proto.MESSAGE,
+        number=7,
+        oneof="job_type",
+        message=gcd_jobs.SparkSqlJob,
     )
     presto_job = proto.Field(
-        proto.MESSAGE, number=12, oneof="job_type", message=gcd_jobs.PrestoJob,
+        proto.MESSAGE,
+        number=12,
+        oneof="job_type",
+        message=gcd_jobs.PrestoJob,
     )
-    labels = proto.MapField(proto.STRING, proto.STRING, number=8,)
-    scheduling = proto.Field(proto.MESSAGE, number=9, message=gcd_jobs.JobScheduling,)
-    prerequisite_step_ids = proto.RepeatedField(proto.STRING, number=10,)
+    labels = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=8,
+    )
+    scheduling = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message=gcd_jobs.JobScheduling,
+    )
+    prerequisite_step_ids = proto.RepeatedField(
+        proto.STRING,
+        number=10,
+    )
 
 
 class TemplateParameter(proto.Message):
@@ -377,10 +472,23 @@ class TemplateParameter(proto.Message):
             this parameter's value.
     """
 
-    name = proto.Field(proto.STRING, number=1,)
-    fields = proto.RepeatedField(proto.STRING, number=2,)
-    description = proto.Field(proto.STRING, number=3,)
-    validation = proto.Field(proto.MESSAGE, number=4, message="ParameterValidation",)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    fields = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    description = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    validation = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message="ParameterValidation",
+    )
 
 
 class ParameterValidation(proto.Message):
@@ -393,10 +501,16 @@ class ParameterValidation(proto.Message):
     """
 
     regex = proto.Field(
-        proto.MESSAGE, number=1, oneof="validation_type", message="RegexValidation",
+        proto.MESSAGE,
+        number=1,
+        oneof="validation_type",
+        message="RegexValidation",
     )
     values = proto.Field(
-        proto.MESSAGE, number=2, oneof="validation_type", message="ValueValidation",
+        proto.MESSAGE,
+        number=2,
+        oneof="validation_type",
+        message="ValueValidation",
     )
 
 
@@ -410,7 +524,10 @@ class RegexValidation(proto.Message):
             matches are not sufficient).
     """
 
-    regexes = proto.RepeatedField(proto.STRING, number=1,)
+    regexes = proto.RepeatedField(
+        proto.STRING,
+        number=1,
+    )
 
 
 class ValueValidation(proto.Message):
@@ -421,7 +538,10 @@ class ValueValidation(proto.Message):
             parameter.
     """
 
-    values = proto.RepeatedField(proto.STRING, number=1,)
+    values = proto.RepeatedField(
+        proto.STRING,
+        number=1,
+    )
 
 
 class WorkflowMetadata(proto.Message):
@@ -484,23 +604,71 @@ class WorkflowMetadata(proto.Message):
         RUNNING = 2
         DONE = 3
 
-    template = proto.Field(proto.STRING, number=1,)
-    version = proto.Field(proto.INT32, number=2,)
-    create_cluster = proto.Field(proto.MESSAGE, number=3, message="ClusterOperation",)
-    graph = proto.Field(proto.MESSAGE, number=4, message="WorkflowGraph",)
-    delete_cluster = proto.Field(proto.MESSAGE, number=5, message="ClusterOperation",)
-    state = proto.Field(proto.ENUM, number=6, enum=State,)
-    cluster_name = proto.Field(proto.STRING, number=7,)
-    parameters = proto.MapField(proto.STRING, proto.STRING, number=8,)
-    start_time = proto.Field(proto.MESSAGE, number=9, message=timestamp_pb2.Timestamp,)
-    end_time = proto.Field(proto.MESSAGE, number=10, message=timestamp_pb2.Timestamp,)
-    cluster_uuid = proto.Field(proto.STRING, number=11,)
-    dag_timeout = proto.Field(proto.MESSAGE, number=12, message=duration_pb2.Duration,)
+    template = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    version = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    create_cluster = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message="ClusterOperation",
+    )
+    graph = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message="WorkflowGraph",
+    )
+    delete_cluster = proto.Field(
+        proto.MESSAGE,
+        number=5,
+        message="ClusterOperation",
+    )
+    state = proto.Field(
+        proto.ENUM,
+        number=6,
+        enum=State,
+    )
+    cluster_name = proto.Field(
+        proto.STRING,
+        number=7,
+    )
+    parameters = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=8,
+    )
+    start_time = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message=timestamp_pb2.Timestamp,
+    )
+    end_time = proto.Field(
+        proto.MESSAGE,
+        number=10,
+        message=timestamp_pb2.Timestamp,
+    )
+    cluster_uuid = proto.Field(
+        proto.STRING,
+        number=11,
+    )
+    dag_timeout = proto.Field(
+        proto.MESSAGE,
+        number=12,
+        message=duration_pb2.Duration,
+    )
     dag_start_time = proto.Field(
-        proto.MESSAGE, number=13, message=timestamp_pb2.Timestamp,
+        proto.MESSAGE,
+        number=13,
+        message=timestamp_pb2.Timestamp,
     )
     dag_end_time = proto.Field(
-        proto.MESSAGE, number=14, message=timestamp_pb2.Timestamp,
+        proto.MESSAGE,
+        number=14,
+        message=timestamp_pb2.Timestamp,
     )
 
 
@@ -515,9 +683,18 @@ class ClusterOperation(proto.Message):
             Output only. Indicates the operation is done.
     """
 
-    operation_id = proto.Field(proto.STRING, number=1,)
-    error = proto.Field(proto.STRING, number=2,)
-    done = proto.Field(proto.BOOL, number=3,)
+    operation_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    error = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    done = proto.Field(
+        proto.BOOL,
+        number=3,
+    )
 
 
 class WorkflowGraph(proto.Message):
@@ -527,7 +704,11 @@ class WorkflowGraph(proto.Message):
             Output only. The workflow nodes.
     """
 
-    nodes = proto.RepeatedField(proto.MESSAGE, number=1, message="WorkflowNode",)
+    nodes = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message="WorkflowNode",
+    )
 
 
 class WorkflowNode(proto.Message):
@@ -555,11 +736,27 @@ class WorkflowNode(proto.Message):
         COMPLETED = 4
         FAILED = 5
 
-    step_id = proto.Field(proto.STRING, number=1,)
-    prerequisite_step_ids = proto.RepeatedField(proto.STRING, number=2,)
-    job_id = proto.Field(proto.STRING, number=3,)
-    state = proto.Field(proto.ENUM, number=5, enum=NodeState,)
-    error = proto.Field(proto.STRING, number=6,)
+    step_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    prerequisite_step_ids = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    job_id = proto.Field(
+        proto.STRING,
+        number=3,
+    )
+    state = proto.Field(
+        proto.ENUM,
+        number=5,
+        enum=NodeState,
+    )
+    error = proto.Field(
+        proto.STRING,
+        number=6,
+    )
 
 
 class CreateWorkflowTemplateRequest(proto.Message):
@@ -582,8 +779,15 @@ class CreateWorkflowTemplateRequest(proto.Message):
             create.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    template = proto.Field(proto.MESSAGE, number=2, message="WorkflowTemplate",)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    template = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="WorkflowTemplate",
+    )
 
 
 class GetWorkflowTemplateRequest(proto.Message):
@@ -608,8 +812,14 @@ class GetWorkflowTemplateRequest(proto.Message):
             If unspecified, retrieves the current version.
     """
 
-    name = proto.Field(proto.STRING, number=1,)
-    version = proto.Field(proto.INT32, number=2,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    version = proto.Field(
+        proto.INT32,
+        number=2,
+    )
 
 
 class InstantiateWorkflowTemplateRequest(proto.Message):
@@ -653,10 +863,23 @@ class InstantiateWorkflowTemplateRequest(proto.Message):
             may not exceed 1000 characters.
     """
 
-    name = proto.Field(proto.STRING, number=1,)
-    version = proto.Field(proto.INT32, number=2,)
-    request_id = proto.Field(proto.STRING, number=5,)
-    parameters = proto.MapField(proto.STRING, proto.STRING, number=6,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    version = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=5,
+    )
+    parameters = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=6,
+    )
 
 
 class InstantiateInlineWorkflowTemplateRequest(proto.Message):
@@ -692,9 +915,19 @@ class InstantiateInlineWorkflowTemplateRequest(proto.Message):
             characters.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    template = proto.Field(proto.MESSAGE, number=2, message="WorkflowTemplate",)
-    request_id = proto.Field(proto.STRING, number=3,)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    template = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message="WorkflowTemplate",
+    )
+    request_id = proto.Field(
+        proto.STRING,
+        number=3,
+    )
 
 
 class UpdateWorkflowTemplateRequest(proto.Message):
@@ -707,7 +940,11 @@ class UpdateWorkflowTemplateRequest(proto.Message):
             version.
     """
 
-    template = proto.Field(proto.MESSAGE, number=1, message="WorkflowTemplate",)
+    template = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message="WorkflowTemplate",
+    )
 
 
 class ListWorkflowTemplatesRequest(proto.Message):
@@ -734,9 +971,18 @@ class ListWorkflowTemplatesRequest(proto.Message):
             results.
     """
 
-    parent = proto.Field(proto.STRING, number=1,)
-    page_size = proto.Field(proto.INT32, number=2,)
-    page_token = proto.Field(proto.STRING, number=3,)
+    parent = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    page_size = proto.Field(
+        proto.INT32,
+        number=2,
+    )
+    page_token = proto.Field(
+        proto.STRING,
+        number=3,
+    )
 
 
 class ListWorkflowTemplatesResponse(proto.Message):
@@ -758,9 +1004,14 @@ class ListWorkflowTemplatesResponse(proto.Message):
         return self
 
     templates = proto.RepeatedField(
-        proto.MESSAGE, number=1, message="WorkflowTemplate",
+        proto.MESSAGE,
+        number=1,
+        message="WorkflowTemplate",
     )
-    next_page_token = proto.Field(proto.STRING, number=2,)
+    next_page_token = proto.Field(
+        proto.STRING,
+        number=2,
+    )
 
 
 class DeleteWorkflowTemplateRequest(proto.Message):
@@ -788,8 +1039,14 @@ class DeleteWorkflowTemplateRequest(proto.Message):
             specified version.
     """
 
-    name = proto.Field(proto.STRING, number=1,)
-    version = proto.Field(proto.INT32, number=2,)
+    name = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    version = proto.Field(
+        proto.INT32,
+        number=2,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ import shutil
 import nox
 
 
-BLACK_VERSION = "black==19.10b0"
+BLACK_VERSION = "black==22.3.0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 DEFAULT_PYTHON_VERSION = "3.8"
@@ -57,7 +57,9 @@ def lint(session):
     """
     session.install("flake8", BLACK_VERSION)
     session.run(
-        "black", "--check", *BLACK_PATHS,
+        "black",
+        "--check",
+        *BLACK_PATHS,
     )
     session.run("flake8", "google", "tests")
 
@@ -67,7 +69,8 @@ def blacken(session):
     """Run black. Format code to uniform standard."""
     session.install(BLACK_VERSION)
     session.run(
-        "black", *BLACK_PATHS,
+        "black",
+        *BLACK_PATHS,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ dependencies = [
     # NOTE: Maintainers, please do not require google-api-core>=2.x.x
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
-    "google-api-core[grpc] >= 1.26.0, <3.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "proto-plus >= 1.4.0",
     "packaging >= 14.3",
 ]

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,9 @@ setuptools.setup(
     install_requires=dependencies,
     extras_require=extras,
     python_requires=">=3.6",
-    scripts=["scripts/fixup_dataproc_v1_keywords.py",],
+    scripts=[
+        "scripts/fixup_dataproc_v1_keywords.py",
+    ],
     include_package_data=True,
     zip_safe=False,
 )

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,8 +5,7 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-google-api-core==1.26.0
+google-api-core==1.31.5
 libcst==0.2.5
 proto-plus==1.4.0
 packaging==14.3
-google-auth==1.24.0  # TODO: remove after google-auth>=1.25.0 is transitively required through google-api-core

--- a/tests/unit/gapic/dataproc_v1/test_autoscaling_policy_service.py
+++ b/tests/unit/gapic/dataproc_v1/test_autoscaling_policy_service.py
@@ -109,7 +109,10 @@ def test__get_default_mtls_endpoint():
 
 @pytest.mark.parametrize(
     "client_class",
-    [AutoscalingPolicyServiceClient, AutoscalingPolicyServiceAsyncClient,],
+    [
+        AutoscalingPolicyServiceClient,
+        AutoscalingPolicyServiceAsyncClient,
+    ],
 )
 def test_autoscaling_policy_service_client_from_service_account_info(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -152,7 +155,10 @@ def test_autoscaling_policy_service_client_service_account_always_use_jwt(
 
 @pytest.mark.parametrize(
     "client_class",
-    [AutoscalingPolicyServiceClient, AutoscalingPolicyServiceAsyncClient,],
+    [
+        AutoscalingPolicyServiceClient,
+        AutoscalingPolicyServiceAsyncClient,
+    ],
 )
 def test_autoscaling_policy_service_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -457,7 +463,9 @@ def test_autoscaling_policy_service_client_client_options_scopes(
     client_class, transport_class, transport_name
 ):
     # Check the case scopes are provided.
-    options = client_options.ClientOptions(scopes=["1", "2"],)
+    options = client_options.ClientOptions(
+        scopes=["1", "2"],
+    )
     with mock.patch.object(transport_class, "__init__") as patched:
         patched.return_value = None
         client = client_class(client_options=options)
@@ -533,7 +541,8 @@ def test_create_autoscaling_policy(
     request_type=autoscaling_policies.CreateAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -575,7 +584,8 @@ def test_create_autoscaling_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -594,7 +604,8 @@ async def test_create_autoscaling_policy_async(
     request_type=autoscaling_policies.CreateAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -607,7 +618,10 @@ async def test_create_autoscaling_policy_async(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            autoscaling_policies.AutoscalingPolicy(id="id_value", name="name_value",)
+            autoscaling_policies.AutoscalingPolicy(
+                id="id_value",
+                name="name_value",
+            )
         )
         response = await client.create_autoscaling_policy(request)
 
@@ -652,7 +666,10 @@ def test_create_autoscaling_policy_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -683,7 +700,10 @@ async def test_create_autoscaling_policy_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_create_autoscaling_policy_flattened():
@@ -779,7 +799,8 @@ def test_update_autoscaling_policy(
     request_type=autoscaling_policies.UpdateAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -821,7 +842,8 @@ def test_update_autoscaling_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -840,7 +862,8 @@ async def test_update_autoscaling_policy_async(
     request_type=autoscaling_policies.UpdateAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -853,7 +876,10 @@ async def test_update_autoscaling_policy_async(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            autoscaling_policies.AutoscalingPolicy(id="id_value", name="name_value",)
+            autoscaling_policies.AutoscalingPolicy(
+                id="id_value",
+                name="name_value",
+            )
         )
         response = await client.update_autoscaling_policy(request)
 
@@ -898,7 +924,10 @@ def test_update_autoscaling_policy_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "policy.name=policy.name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "policy.name=policy.name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -929,7 +958,10 @@ async def test_update_autoscaling_policy_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "policy.name=policy.name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "policy.name=policy.name/value",
+    ) in kw["metadata"]
 
 
 def test_update_autoscaling_policy_flattened():
@@ -1019,7 +1051,8 @@ def test_get_autoscaling_policy(
     request_type=autoscaling_policies.GetAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1061,7 +1094,8 @@ def test_get_autoscaling_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1080,7 +1114,8 @@ async def test_get_autoscaling_policy_async(
     request_type=autoscaling_policies.GetAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1093,7 +1128,10 @@ async def test_get_autoscaling_policy_async(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            autoscaling_policies.AutoscalingPolicy(id="id_value", name="name_value",)
+            autoscaling_policies.AutoscalingPolicy(
+                id="id_value",
+                name="name_value",
+            )
         )
         response = await client.get_autoscaling_policy(request)
 
@@ -1138,7 +1176,10 @@ def test_get_autoscaling_policy_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1169,7 +1210,10 @@ async def test_get_autoscaling_policy_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_get_autoscaling_policy_flattened():
@@ -1185,7 +1229,9 @@ def test_get_autoscaling_policy_flattened():
         call.return_value = autoscaling_policies.AutoscalingPolicy()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.get_autoscaling_policy(name="name_value",)
+        client.get_autoscaling_policy(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1203,7 +1249,8 @@ def test_get_autoscaling_policy_flattened_error():
     # fields is an error.
     with pytest.raises(ValueError):
         client.get_autoscaling_policy(
-            autoscaling_policies.GetAutoscalingPolicyRequest(), name="name_value",
+            autoscaling_policies.GetAutoscalingPolicyRequest(),
+            name="name_value",
         )
 
 
@@ -1225,7 +1272,9 @@ async def test_get_autoscaling_policy_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.get_autoscaling_policy(name="name_value",)
+        response = await client.get_autoscaling_policy(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1244,7 +1293,8 @@ async def test_get_autoscaling_policy_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.get_autoscaling_policy(
-            autoscaling_policies.GetAutoscalingPolicyRequest(), name="name_value",
+            autoscaling_policies.GetAutoscalingPolicyRequest(),
+            name="name_value",
         )
 
 
@@ -1253,7 +1303,8 @@ def test_list_autoscaling_policies(
     request_type=autoscaling_policies.ListAutoscalingPoliciesRequest,
 ):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1288,7 +1339,8 @@ def test_list_autoscaling_policies_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1307,7 +1359,8 @@ async def test_list_autoscaling_policies_async(
     request_type=autoscaling_policies.ListAutoscalingPoliciesRequest,
 ):
     client = AutoscalingPolicyServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1366,7 +1419,10 @@ def test_list_autoscaling_policies_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1397,7 +1453,10 @@ async def test_list_autoscaling_policies_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_list_autoscaling_policies_flattened():
@@ -1413,7 +1472,9 @@ def test_list_autoscaling_policies_flattened():
         call.return_value = autoscaling_policies.ListAutoscalingPoliciesResponse()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.list_autoscaling_policies(parent="parent_value",)
+        client.list_autoscaling_policies(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1454,7 +1515,9 @@ async def test_list_autoscaling_policies_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.list_autoscaling_policies(parent="parent_value",)
+        response = await client.list_autoscaling_policies(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1498,10 +1561,13 @@ def test_list_autoscaling_policies_pager():
                 next_page_token="abc",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[], next_page_token="def",
+                policies=[],
+                next_page_token="def",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[autoscaling_policies.AutoscalingPolicy(),],
+                policies=[
+                    autoscaling_policies.AutoscalingPolicy(),
+                ],
                 next_page_token="ghi",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
@@ -1548,10 +1614,13 @@ def test_list_autoscaling_policies_pages():
                 next_page_token="abc",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[], next_page_token="def",
+                policies=[],
+                next_page_token="def",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[autoscaling_policies.AutoscalingPolicy(),],
+                policies=[
+                    autoscaling_policies.AutoscalingPolicy(),
+                ],
                 next_page_token="ghi",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
@@ -1590,10 +1659,13 @@ async def test_list_autoscaling_policies_async_pager():
                 next_page_token="abc",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[], next_page_token="def",
+                policies=[],
+                next_page_token="def",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[autoscaling_policies.AutoscalingPolicy(),],
+                policies=[
+                    autoscaling_policies.AutoscalingPolicy(),
+                ],
                 next_page_token="ghi",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
@@ -1604,7 +1676,9 @@ async def test_list_autoscaling_policies_async_pager():
             ),
             RuntimeError,
         )
-        async_pager = await client.list_autoscaling_policies(request={},)
+        async_pager = await client.list_autoscaling_policies(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -1639,10 +1713,13 @@ async def test_list_autoscaling_policies_async_pages():
                 next_page_token="abc",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[], next_page_token="def",
+                policies=[],
+                next_page_token="def",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
-                policies=[autoscaling_policies.AutoscalingPolicy(),],
+                policies=[
+                    autoscaling_policies.AutoscalingPolicy(),
+                ],
                 next_page_token="ghi",
             ),
             autoscaling_policies.ListAutoscalingPoliciesResponse(
@@ -1665,7 +1742,8 @@ def test_delete_autoscaling_policy(
     request_type=autoscaling_policies.DeleteAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1697,7 +1775,8 @@ def test_delete_autoscaling_policy_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = AutoscalingPolicyServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1716,7 +1795,8 @@ async def test_delete_autoscaling_policy_async(
     request_type=autoscaling_policies.DeleteAutoscalingPolicyRequest,
 ):
     client = AutoscalingPolicyServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1770,7 +1850,10 @@ def test_delete_autoscaling_policy_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1799,7 +1882,10 @@ async def test_delete_autoscaling_policy_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_delete_autoscaling_policy_flattened():
@@ -1815,7 +1901,9 @@ def test_delete_autoscaling_policy_flattened():
         call.return_value = None
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.delete_autoscaling_policy(name="name_value",)
+        client.delete_autoscaling_policy(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1833,7 +1921,8 @@ def test_delete_autoscaling_policy_flattened_error():
     # fields is an error.
     with pytest.raises(ValueError):
         client.delete_autoscaling_policy(
-            autoscaling_policies.DeleteAutoscalingPolicyRequest(), name="name_value",
+            autoscaling_policies.DeleteAutoscalingPolicyRequest(),
+            name="name_value",
         )
 
 
@@ -1853,7 +1942,9 @@ async def test_delete_autoscaling_policy_flattened_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.delete_autoscaling_policy(name="name_value",)
+        response = await client.delete_autoscaling_policy(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1872,7 +1963,8 @@ async def test_delete_autoscaling_policy_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.delete_autoscaling_policy(
-            autoscaling_policies.DeleteAutoscalingPolicyRequest(), name="name_value",
+            autoscaling_policies.DeleteAutoscalingPolicyRequest(),
+            name="name_value",
         )
 
 
@@ -1883,7 +1975,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = AutoscalingPolicyServiceClient(
-            credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
@@ -1902,7 +1995,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = AutoscalingPolicyServiceClient(
-            client_options={"scopes": ["1", "2"]}, transport=transport,
+            client_options={"scopes": ["1", "2"]},
+            transport=transport,
         )
 
 
@@ -1951,7 +2045,8 @@ def test_transport_grpc_default():
         credentials=ga_credentials.AnonymousCredentials(),
     )
     assert isinstance(
-        client.transport, transports.AutoscalingPolicyServiceGrpcTransport,
+        client.transport,
+        transports.AutoscalingPolicyServiceGrpcTransport,
     )
 
 
@@ -1999,7 +2094,8 @@ def test_autoscaling_policy_service_base_transport_with_credentials_file():
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.AutoscalingPolicyServiceTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -2020,7 +2116,8 @@ def test_autoscaling_policy_service_base_transport_with_credentials_file_old_goo
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.AutoscalingPolicyServiceTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -2215,7 +2312,8 @@ def test_autoscaling_policy_service_grpc_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.AutoscalingPolicyServiceGrpcTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2227,7 +2325,8 @@ def test_autoscaling_policy_service_grpc_asyncio_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.AutoscalingPolicyServiceGrpcAsyncIOTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2339,7 +2438,9 @@ def test_autoscaling_policy_path():
     location = "clam"
     autoscaling_policy = "whelk"
     expected = "projects/{project}/locations/{location}/autoscalingPolicies/{autoscaling_policy}".format(
-        project=project, location=location, autoscaling_policy=autoscaling_policy,
+        project=project,
+        location=location,
+        autoscaling_policy=autoscaling_policy,
     )
     actual = AutoscalingPolicyServiceClient.autoscaling_policy_path(
         project, location, autoscaling_policy
@@ -2382,7 +2483,9 @@ def test_parse_common_billing_account_path():
 
 def test_common_folder_path():
     folder = "winkle"
-    expected = "folders/{folder}".format(folder=folder,)
+    expected = "folders/{folder}".format(
+        folder=folder,
+    )
     actual = AutoscalingPolicyServiceClient.common_folder_path(folder)
     assert expected == actual
 
@@ -2400,7 +2503,9 @@ def test_parse_common_folder_path():
 
 def test_common_organization_path():
     organization = "scallop"
-    expected = "organizations/{organization}".format(organization=organization,)
+    expected = "organizations/{organization}".format(
+        organization=organization,
+    )
     actual = AutoscalingPolicyServiceClient.common_organization_path(organization)
     assert expected == actual
 
@@ -2418,7 +2523,9 @@ def test_parse_common_organization_path():
 
 def test_common_project_path():
     project = "squid"
-    expected = "projects/{project}".format(project=project,)
+    expected = "projects/{project}".format(
+        project=project,
+    )
     actual = AutoscalingPolicyServiceClient.common_project_path(project)
     assert expected == actual
 
@@ -2438,7 +2545,8 @@ def test_common_location_path():
     project = "whelk"
     location = "octopus"
     expected = "projects/{project}/locations/{location}".format(
-        project=project, location=location,
+        project=project,
+        location=location,
     )
     actual = AutoscalingPolicyServiceClient.common_location_path(project, location)
     assert expected == actual
@@ -2463,7 +2571,8 @@ def test_client_withDEFAULT_CLIENT_INFO():
         transports.AutoscalingPolicyServiceTransport, "_prep_wrapped_messages"
     ) as prep:
         client = AutoscalingPolicyServiceClient(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -2472,6 +2581,7 @@ def test_client_withDEFAULT_CLIENT_INFO():
     ) as prep:
         transport_class = AutoscalingPolicyServiceClient.get_transport_class()
         transport = transport_class(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)

--- a/tests/unit/gapic/dataproc_v1/test_cluster_controller.py
+++ b/tests/unit/gapic/dataproc_v1/test_cluster_controller.py
@@ -114,7 +114,11 @@ def test__get_default_mtls_endpoint():
 
 
 @pytest.mark.parametrize(
-    "client_class", [ClusterControllerClient, ClusterControllerAsyncClient,]
+    "client_class",
+    [
+        ClusterControllerClient,
+        ClusterControllerAsyncClient,
+    ],
 )
 def test_cluster_controller_client_from_service_account_info(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -156,7 +160,11 @@ def test_cluster_controller_client_service_account_always_use_jwt(
 
 
 @pytest.mark.parametrize(
-    "client_class", [ClusterControllerClient, ClusterControllerAsyncClient,]
+    "client_class",
+    [
+        ClusterControllerClient,
+        ClusterControllerAsyncClient,
+    ],
 )
 def test_cluster_controller_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -449,7 +457,9 @@ def test_cluster_controller_client_client_options_scopes(
     client_class, transport_class, transport_name
 ):
     # Check the case scopes are provided.
-    options = client_options.ClientOptions(scopes=["1", "2"],)
+    options = client_options.ClientOptions(
+        scopes=["1", "2"],
+    )
     with mock.patch.object(transport_class, "__init__") as patched:
         patched.return_value = None
         client = client_class(client_options=options)
@@ -520,7 +530,8 @@ def test_create_cluster(
     transport: str = "grpc", request_type=clusters.CreateClusterRequest
 ):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -550,7 +561,8 @@ def test_create_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -566,7 +578,8 @@ async def test_create_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.CreateClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -596,7 +609,9 @@ async def test_create_cluster_async_from_dict():
 
 
 def test_create_cluster_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_cluster), "__call__") as call:
@@ -620,7 +635,9 @@ def test_create_cluster_flattened():
 
 
 def test_create_cluster_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -685,7 +702,8 @@ def test_update_cluster(
     transport: str = "grpc", request_type=clusters.UpdateClusterRequest
 ):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -715,7 +733,8 @@ def test_update_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -731,7 +750,8 @@ async def test_update_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.UpdateClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -761,7 +781,9 @@ async def test_update_cluster_async_from_dict():
 
 
 def test_update_cluster_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_cluster), "__call__") as call:
@@ -789,7 +811,9 @@ def test_update_cluster_flattened():
 
 
 def test_update_cluster_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -862,7 +886,8 @@ def test_stop_cluster(
     transport: str = "grpc", request_type=clusters.StopClusterRequest
 ):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -892,7 +917,8 @@ def test_stop_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -908,7 +934,8 @@ async def test_stop_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.StopClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -941,7 +968,8 @@ def test_start_cluster(
     transport: str = "grpc", request_type=clusters.StartClusterRequest
 ):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -971,7 +999,8 @@ def test_start_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -987,7 +1016,8 @@ async def test_start_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.StartClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1020,7 +1050,8 @@ def test_delete_cluster(
     transport: str = "grpc", request_type=clusters.DeleteClusterRequest
 ):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1050,7 +1081,8 @@ def test_delete_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1066,7 +1098,8 @@ async def test_delete_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.DeleteClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1096,7 +1129,9 @@ async def test_delete_cluster_async_from_dict():
 
 
 def test_delete_cluster_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_cluster), "__call__") as call:
@@ -1120,7 +1155,9 @@ def test_delete_cluster_flattened():
 
 
 def test_delete_cluster_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1183,7 +1220,8 @@ async def test_delete_cluster_flattened_error_async():
 
 def test_get_cluster(transport: str = "grpc", request_type=clusters.GetClusterRequest):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1220,7 +1258,8 @@ def test_get_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1236,7 +1275,8 @@ async def test_get_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.GetClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1273,7 +1313,9 @@ async def test_get_cluster_async_from_dict():
 
 
 def test_get_cluster_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_cluster), "__call__") as call:
@@ -1297,7 +1339,9 @@ def test_get_cluster_flattened():
 
 
 def test_get_cluster_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1360,7 +1404,8 @@ def test_list_clusters(
     transport: str = "grpc", request_type=clusters.ListClustersRequest
 ):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1393,7 +1438,8 @@ def test_list_clusters_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1409,7 +1455,8 @@ async def test_list_clusters_async(
     transport: str = "grpc_asyncio", request_type=clusters.ListClustersRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1420,7 +1467,9 @@ async def test_list_clusters_async(
     with mock.patch.object(type(client.transport.list_clusters), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            clusters.ListClustersResponse(next_page_token="next_page_token_value",)
+            clusters.ListClustersResponse(
+                next_page_token="next_page_token_value",
+            )
         )
         response = await client.list_clusters(request)
 
@@ -1440,7 +1489,9 @@ async def test_list_clusters_async_from_dict():
 
 
 def test_list_clusters_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_clusters), "__call__") as call:
@@ -1449,7 +1500,9 @@ def test_list_clusters_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.list_clusters(
-            project_id="project_id_value", region="region_value", filter="filter_value",
+            project_id="project_id_value",
+            region="region_value",
+            filter="filter_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1462,7 +1515,9 @@ def test_list_clusters_flattened():
 
 
 def test_list_clusters_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1492,7 +1547,9 @@ async def test_list_clusters_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.list_clusters(
-            project_id="project_id_value", region="region_value", filter="filter_value",
+            project_id="project_id_value",
+            region="region_value",
+            filter="filter_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1522,22 +1579,37 @@ async def test_list_clusters_flattened_error_async():
 
 
 def test_list_clusters_pager():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials,)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_clusters), "__call__") as call:
         # Set the response to a series of pages.
         call.side_effect = (
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
                 next_page_token="abc",
             ),
-            clusters.ListClustersResponse(clusters=[], next_page_token="def",),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(),], next_page_token="ghi",
+                clusters=[],
+                next_page_token="def",
             ),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                ],
+                next_page_token="ghi",
+            ),
+            clusters.ListClustersResponse(
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
             ),
             RuntimeError,
         )
@@ -1553,22 +1625,37 @@ def test_list_clusters_pager():
 
 
 def test_list_clusters_pages():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials,)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_clusters), "__call__") as call:
         # Set the response to a series of pages.
         call.side_effect = (
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
                 next_page_token="abc",
             ),
-            clusters.ListClustersResponse(clusters=[], next_page_token="def",),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(),], next_page_token="ghi",
+                clusters=[],
+                next_page_token="def",
             ),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                ],
+                next_page_token="ghi",
+            ),
+            clusters.ListClustersResponse(
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
             ),
             RuntimeError,
         )
@@ -1590,19 +1677,34 @@ async def test_list_clusters_async_pager():
         # Set the response to a series of pages.
         call.side_effect = (
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
                 next_page_token="abc",
             ),
-            clusters.ListClustersResponse(clusters=[], next_page_token="def",),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(),], next_page_token="ghi",
+                clusters=[],
+                next_page_token="def",
             ),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                ],
+                next_page_token="ghi",
+            ),
+            clusters.ListClustersResponse(
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
             ),
             RuntimeError,
         )
-        async_pager = await client.list_clusters(request={},)
+        async_pager = await client.list_clusters(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -1625,15 +1727,28 @@ async def test_list_clusters_async_pages():
         # Set the response to a series of pages.
         call.side_effect = (
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
                 next_page_token="abc",
             ),
-            clusters.ListClustersResponse(clusters=[], next_page_token="def",),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(),], next_page_token="ghi",
+                clusters=[],
+                next_page_token="def",
             ),
             clusters.ListClustersResponse(
-                clusters=[clusters.Cluster(), clusters.Cluster(),],
+                clusters=[
+                    clusters.Cluster(),
+                ],
+                next_page_token="ghi",
+            ),
+            clusters.ListClustersResponse(
+                clusters=[
+                    clusters.Cluster(),
+                    clusters.Cluster(),
+                ],
             ),
             RuntimeError,
         )
@@ -1648,7 +1763,8 @@ def test_diagnose_cluster(
     transport: str = "grpc", request_type=clusters.DiagnoseClusterRequest
 ):
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1678,7 +1794,8 @@ def test_diagnose_cluster_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1694,7 +1811,8 @@ async def test_diagnose_cluster_async(
     transport: str = "grpc_asyncio", request_type=clusters.DiagnoseClusterRequest
 ):
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1724,7 +1842,9 @@ async def test_diagnose_cluster_async_from_dict():
 
 
 def test_diagnose_cluster_flattened():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.diagnose_cluster), "__call__") as call:
@@ -1748,7 +1868,9 @@ def test_diagnose_cluster_flattened():
 
 
 def test_diagnose_cluster_flattened_error():
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1816,7 +1938,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = ClusterControllerClient(
-            credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
@@ -1835,7 +1958,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = ClusterControllerClient(
-            client_options={"scopes": ["1", "2"]}, transport=transport,
+            client_options={"scopes": ["1", "2"]},
+            transport=transport,
         )
 
 
@@ -1880,8 +2004,13 @@ def test_transport_adc(transport_class):
 
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
-    client = ClusterControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
-    assert isinstance(client.transport, transports.ClusterControllerGrpcTransport,)
+    client = ClusterControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    assert isinstance(
+        client.transport,
+        transports.ClusterControllerGrpcTransport,
+    )
 
 
 def test_cluster_controller_base_transport_error():
@@ -1936,7 +2065,8 @@ def test_cluster_controller_base_transport_with_credentials_file():
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.ClusterControllerTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -1957,7 +2087,8 @@ def test_cluster_controller_base_transport_with_credentials_file_old_google_auth
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.ClusterControllerTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -2148,7 +2279,8 @@ def test_cluster_controller_grpc_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.ClusterControllerGrpcTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2160,7 +2292,8 @@ def test_cluster_controller_grpc_asyncio_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.ClusterControllerGrpcAsyncIOTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2269,12 +2402,16 @@ def test_cluster_controller_transport_channel_mtls_with_adc(transport_class):
 
 def test_cluster_controller_grpc_lro_client():
     client = ClusterControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2282,12 +2419,16 @@ def test_cluster_controller_grpc_lro_client():
 
 def test_cluster_controller_grpc_lro_async_client():
     client = ClusterControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsAsyncClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsAsyncClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2298,7 +2439,9 @@ def test_cluster_path():
     location = "clam"
     cluster = "whelk"
     expected = "projects/{project}/locations/{location}/clusters/{cluster}".format(
-        project=project, location=location, cluster=cluster,
+        project=project,
+        location=location,
+        cluster=cluster,
     )
     actual = ClusterControllerClient.cluster_path(project, location, cluster)
     assert expected == actual
@@ -2322,7 +2465,9 @@ def test_service_path():
     location = "mussel"
     service = "winkle"
     expected = "projects/{project}/locations/{location}/services/{service}".format(
-        project=project, location=location, service=service,
+        project=project,
+        location=location,
+        service=service,
     )
     actual = ClusterControllerClient.service_path(project, location, service)
     assert expected == actual
@@ -2363,7 +2508,9 @@ def test_parse_common_billing_account_path():
 
 def test_common_folder_path():
     folder = "whelk"
-    expected = "folders/{folder}".format(folder=folder,)
+    expected = "folders/{folder}".format(
+        folder=folder,
+    )
     actual = ClusterControllerClient.common_folder_path(folder)
     assert expected == actual
 
@@ -2381,7 +2528,9 @@ def test_parse_common_folder_path():
 
 def test_common_organization_path():
     organization = "oyster"
-    expected = "organizations/{organization}".format(organization=organization,)
+    expected = "organizations/{organization}".format(
+        organization=organization,
+    )
     actual = ClusterControllerClient.common_organization_path(organization)
     assert expected == actual
 
@@ -2399,7 +2548,9 @@ def test_parse_common_organization_path():
 
 def test_common_project_path():
     project = "cuttlefish"
-    expected = "projects/{project}".format(project=project,)
+    expected = "projects/{project}".format(
+        project=project,
+    )
     actual = ClusterControllerClient.common_project_path(project)
     assert expected == actual
 
@@ -2419,7 +2570,8 @@ def test_common_location_path():
     project = "winkle"
     location = "nautilus"
     expected = "projects/{project}/locations/{location}".format(
-        project=project, location=location,
+        project=project,
+        location=location,
     )
     actual = ClusterControllerClient.common_location_path(project, location)
     assert expected == actual
@@ -2444,7 +2596,8 @@ def test_client_withDEFAULT_CLIENT_INFO():
         transports.ClusterControllerTransport, "_prep_wrapped_messages"
     ) as prep:
         client = ClusterControllerClient(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -2453,6 +2606,7 @@ def test_client_withDEFAULT_CLIENT_INFO():
     ) as prep:
         transport_class = ClusterControllerClient.get_transport_class()
         transport = transport_class(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)

--- a/tests/unit/gapic/dataproc_v1/test_job_controller.py
+++ b/tests/unit/gapic/dataproc_v1/test_job_controller.py
@@ -108,7 +108,11 @@ def test__get_default_mtls_endpoint():
 
 
 @pytest.mark.parametrize(
-    "client_class", [JobControllerClient, JobControllerAsyncClient,]
+    "client_class",
+    [
+        JobControllerClient,
+        JobControllerAsyncClient,
+    ],
 )
 def test_job_controller_client_from_service_account_info(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -150,7 +154,11 @@ def test_job_controller_client_service_account_always_use_jwt(
 
 
 @pytest.mark.parametrize(
-    "client_class", [JobControllerClient, JobControllerAsyncClient,]
+    "client_class",
+    [
+        JobControllerClient,
+        JobControllerAsyncClient,
+    ],
 )
 def test_job_controller_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -433,7 +441,9 @@ def test_job_controller_client_client_options_scopes(
     client_class, transport_class, transport_name
 ):
     # Check the case scopes are provided.
-    options = client_options.ClientOptions(scopes=["1", "2"],)
+    options = client_options.ClientOptions(
+        scopes=["1", "2"],
+    )
     with mock.patch.object(transport_class, "__init__") as patched:
         patched.return_value = None
         client = client_class(client_options=options)
@@ -502,7 +512,8 @@ def test_job_controller_client_client_options_from_dict():
 
 def test_submit_job(transport: str = "grpc", request_type=jobs.SubmitJobRequest):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -542,7 +553,8 @@ def test_submit_job_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -558,7 +570,8 @@ async def test_submit_job_async(
     transport: str = "grpc_asyncio", request_type=jobs.SubmitJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -597,7 +610,9 @@ async def test_submit_job_async_from_dict():
 
 
 def test_submit_job_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.submit_job), "__call__") as call:
@@ -623,7 +638,9 @@ def test_submit_job_flattened():
 
 
 def test_submit_job_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -688,7 +705,8 @@ def test_submit_job_as_operation(
     transport: str = "grpc", request_type=jobs.SubmitJobRequest
 ):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -720,7 +738,8 @@ def test_submit_job_as_operation_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -738,7 +757,8 @@ async def test_submit_job_as_operation_async(
     transport: str = "grpc_asyncio", request_type=jobs.SubmitJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -770,7 +790,9 @@ async def test_submit_job_as_operation_async_from_dict():
 
 
 def test_submit_job_as_operation_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -798,7 +820,9 @@ def test_submit_job_as_operation_flattened():
 
 
 def test_submit_job_as_operation_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -865,7 +889,8 @@ async def test_submit_job_as_operation_flattened_error_async():
 
 def test_get_job(transport: str = "grpc", request_type=jobs.GetJobRequest):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -905,7 +930,8 @@ def test_get_job_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -921,7 +947,8 @@ async def test_get_job_async(
     transport: str = "grpc_asyncio", request_type=jobs.GetJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -960,7 +987,9 @@ async def test_get_job_async_from_dict():
 
 
 def test_get_job_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_job), "__call__") as call:
@@ -969,7 +998,9 @@ def test_get_job_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.get_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -982,7 +1013,9 @@ def test_get_job_flattened():
 
 
 def test_get_job_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1010,7 +1043,9 @@ async def test_get_job_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.get_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1041,7 +1076,8 @@ async def test_get_job_flattened_error_async():
 
 def test_list_jobs(transport: str = "grpc", request_type=jobs.ListJobsRequest):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1074,7 +1110,8 @@ def test_list_jobs_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1090,7 +1127,8 @@ async def test_list_jobs_async(
     transport: str = "grpc_asyncio", request_type=jobs.ListJobsRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1101,7 +1139,9 @@ async def test_list_jobs_async(
     with mock.patch.object(type(client.transport.list_jobs), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            jobs.ListJobsResponse(next_page_token="next_page_token_value",)
+            jobs.ListJobsResponse(
+                next_page_token="next_page_token_value",
+            )
         )
         response = await client.list_jobs(request)
 
@@ -1121,7 +1161,9 @@ async def test_list_jobs_async_from_dict():
 
 
 def test_list_jobs_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_jobs), "__call__") as call:
@@ -1130,7 +1172,9 @@ def test_list_jobs_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.list_jobs(
-            project_id="project_id_value", region="region_value", filter="filter_value",
+            project_id="project_id_value",
+            region="region_value",
+            filter="filter_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1143,7 +1187,9 @@ def test_list_jobs_flattened():
 
 
 def test_list_jobs_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1173,7 +1219,9 @@ async def test_list_jobs_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.list_jobs(
-            project_id="project_id_value", region="region_value", filter="filter_value",
+            project_id="project_id_value",
+            region="region_value",
+            filter="filter_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1203,18 +1251,38 @@ async def test_list_jobs_flattened_error_async():
 
 
 def test_list_jobs_pager():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials,)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_jobs), "__call__") as call:
         # Set the response to a series of pages.
         call.side_effect = (
             jobs.ListJobsResponse(
-                jobs=[jobs.Job(), jobs.Job(), jobs.Job(),], next_page_token="abc",
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+                next_page_token="abc",
             ),
-            jobs.ListJobsResponse(jobs=[], next_page_token="def",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(),], next_page_token="ghi",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(), jobs.Job(),],),
+            jobs.ListJobsResponse(
+                jobs=[],
+                next_page_token="def",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                ],
+                next_page_token="ghi",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+            ),
             RuntimeError,
         )
 
@@ -1229,18 +1297,38 @@ def test_list_jobs_pager():
 
 
 def test_list_jobs_pages():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials,)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_jobs), "__call__") as call:
         # Set the response to a series of pages.
         call.side_effect = (
             jobs.ListJobsResponse(
-                jobs=[jobs.Job(), jobs.Job(), jobs.Job(),], next_page_token="abc",
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+                next_page_token="abc",
             ),
-            jobs.ListJobsResponse(jobs=[], next_page_token="def",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(),], next_page_token="ghi",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(), jobs.Job(),],),
+            jobs.ListJobsResponse(
+                jobs=[],
+                next_page_token="def",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                ],
+                next_page_token="ghi",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+            ),
             RuntimeError,
         )
         pages = list(client.list_jobs(request={}).pages)
@@ -1250,7 +1338,9 @@ def test_list_jobs_pages():
 
 @pytest.mark.asyncio
 async def test_list_jobs_async_pager():
-    client = JobControllerAsyncClient(credentials=ga_credentials.AnonymousCredentials,)
+    client = JobControllerAsyncClient(
+        credentials=ga_credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1259,14 +1349,34 @@ async def test_list_jobs_async_pager():
         # Set the response to a series of pages.
         call.side_effect = (
             jobs.ListJobsResponse(
-                jobs=[jobs.Job(), jobs.Job(), jobs.Job(),], next_page_token="abc",
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+                next_page_token="abc",
             ),
-            jobs.ListJobsResponse(jobs=[], next_page_token="def",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(),], next_page_token="ghi",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(), jobs.Job(),],),
+            jobs.ListJobsResponse(
+                jobs=[],
+                next_page_token="def",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                ],
+                next_page_token="ghi",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+            ),
             RuntimeError,
         )
-        async_pager = await client.list_jobs(request={},)
+        async_pager = await client.list_jobs(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -1278,7 +1388,9 @@ async def test_list_jobs_async_pager():
 
 @pytest.mark.asyncio
 async def test_list_jobs_async_pages():
-    client = JobControllerAsyncClient(credentials=ga_credentials.AnonymousCredentials,)
+    client = JobControllerAsyncClient(
+        credentials=ga_credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1287,11 +1399,29 @@ async def test_list_jobs_async_pages():
         # Set the response to a series of pages.
         call.side_effect = (
             jobs.ListJobsResponse(
-                jobs=[jobs.Job(), jobs.Job(), jobs.Job(),], next_page_token="abc",
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+                next_page_token="abc",
             ),
-            jobs.ListJobsResponse(jobs=[], next_page_token="def",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(),], next_page_token="ghi",),
-            jobs.ListJobsResponse(jobs=[jobs.Job(), jobs.Job(),],),
+            jobs.ListJobsResponse(
+                jobs=[],
+                next_page_token="def",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                ],
+                next_page_token="ghi",
+            ),
+            jobs.ListJobsResponse(
+                jobs=[
+                    jobs.Job(),
+                    jobs.Job(),
+                ],
+            ),
             RuntimeError,
         )
         pages = []
@@ -1303,7 +1433,8 @@ async def test_list_jobs_async_pages():
 
 def test_update_job(transport: str = "grpc", request_type=jobs.UpdateJobRequest):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1343,7 +1474,8 @@ def test_update_job_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1359,7 +1491,8 @@ async def test_update_job_async(
     transport: str = "grpc_asyncio", request_type=jobs.UpdateJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1399,7 +1532,8 @@ async def test_update_job_async_from_dict():
 
 def test_cancel_job(transport: str = "grpc", request_type=jobs.CancelJobRequest):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1439,7 +1573,8 @@ def test_cancel_job_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1455,7 +1590,8 @@ async def test_cancel_job_async(
     transport: str = "grpc_asyncio", request_type=jobs.CancelJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1494,7 +1630,9 @@ async def test_cancel_job_async_from_dict():
 
 
 def test_cancel_job_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.cancel_job), "__call__") as call:
@@ -1503,7 +1641,9 @@ def test_cancel_job_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.cancel_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1516,7 +1656,9 @@ def test_cancel_job_flattened():
 
 
 def test_cancel_job_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1544,7 +1686,9 @@ async def test_cancel_job_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.cancel_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1575,7 +1719,8 @@ async def test_cancel_job_flattened_error_async():
 
 def test_delete_job(transport: str = "grpc", request_type=jobs.DeleteJobRequest):
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1605,7 +1750,8 @@ def test_delete_job_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1621,7 +1767,8 @@ async def test_delete_job_async(
     transport: str = "grpc_asyncio", request_type=jobs.DeleteJobRequest
 ):
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1649,7 +1796,9 @@ async def test_delete_job_async_from_dict():
 
 
 def test_delete_job_flattened():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_job), "__call__") as call:
@@ -1658,7 +1807,9 @@ def test_delete_job_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.delete_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1671,7 +1822,9 @@ def test_delete_job_flattened():
 
 
 def test_delete_job_flattened_error():
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1699,7 +1852,9 @@ async def test_delete_job_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.delete_job(
-            project_id="project_id_value", region="region_value", job_id="job_id_value",
+            project_id="project_id_value",
+            region="region_value",
+            job_id="job_id_value",
         )
 
         # Establish that the underlying call was made with the expected
@@ -1735,7 +1890,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = JobControllerClient(
-            credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
@@ -1754,7 +1910,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = JobControllerClient(
-            client_options={"scopes": ["1", "2"]}, transport=transport,
+            client_options={"scopes": ["1", "2"]},
+            transport=transport,
         )
 
 
@@ -1799,8 +1956,13 @@ def test_transport_adc(transport_class):
 
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
-    client = JobControllerClient(credentials=ga_credentials.AnonymousCredentials(),)
-    assert isinstance(client.transport, transports.JobControllerGrpcTransport,)
+    client = JobControllerClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    assert isinstance(
+        client.transport,
+        transports.JobControllerGrpcTransport,
+    )
 
 
 def test_job_controller_base_transport_error():
@@ -1854,7 +2016,8 @@ def test_job_controller_base_transport_with_credentials_file():
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.JobControllerTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -1875,7 +2038,8 @@ def test_job_controller_base_transport_with_credentials_file_old_google_auth():
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.JobControllerTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -2066,7 +2230,8 @@ def test_job_controller_grpc_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.JobControllerGrpcTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2078,7 +2243,8 @@ def test_job_controller_grpc_asyncio_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.JobControllerGrpcAsyncIOTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2185,12 +2351,16 @@ def test_job_controller_transport_channel_mtls_with_adc(transport_class):
 
 def test_job_controller_grpc_lro_client():
     client = JobControllerClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2198,12 +2368,16 @@ def test_job_controller_grpc_lro_client():
 
 def test_job_controller_grpc_lro_async_client():
     client = JobControllerAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsAsyncClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsAsyncClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2231,7 +2405,9 @@ def test_parse_common_billing_account_path():
 
 def test_common_folder_path():
     folder = "whelk"
-    expected = "folders/{folder}".format(folder=folder,)
+    expected = "folders/{folder}".format(
+        folder=folder,
+    )
     actual = JobControllerClient.common_folder_path(folder)
     assert expected == actual
 
@@ -2249,7 +2425,9 @@ def test_parse_common_folder_path():
 
 def test_common_organization_path():
     organization = "oyster"
-    expected = "organizations/{organization}".format(organization=organization,)
+    expected = "organizations/{organization}".format(
+        organization=organization,
+    )
     actual = JobControllerClient.common_organization_path(organization)
     assert expected == actual
 
@@ -2267,7 +2445,9 @@ def test_parse_common_organization_path():
 
 def test_common_project_path():
     project = "cuttlefish"
-    expected = "projects/{project}".format(project=project,)
+    expected = "projects/{project}".format(
+        project=project,
+    )
     actual = JobControllerClient.common_project_path(project)
     assert expected == actual
 
@@ -2287,7 +2467,8 @@ def test_common_location_path():
     project = "winkle"
     location = "nautilus"
     expected = "projects/{project}/locations/{location}".format(
-        project=project, location=location,
+        project=project,
+        location=location,
     )
     actual = JobControllerClient.common_location_path(project, location)
     assert expected == actual
@@ -2312,7 +2493,8 @@ def test_client_withDEFAULT_CLIENT_INFO():
         transports.JobControllerTransport, "_prep_wrapped_messages"
     ) as prep:
         client = JobControllerClient(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -2321,6 +2503,7 @@ def test_client_withDEFAULT_CLIENT_INFO():
     ) as prep:
         transport_class = JobControllerClient.get_transport_class()
         transport = transport_class(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)

--- a/tests/unit/gapic/dataproc_v1/test_workflow_template_service.py
+++ b/tests/unit/gapic/dataproc_v1/test_workflow_template_service.py
@@ -116,7 +116,11 @@ def test__get_default_mtls_endpoint():
 
 
 @pytest.mark.parametrize(
-    "client_class", [WorkflowTemplateServiceClient, WorkflowTemplateServiceAsyncClient,]
+    "client_class",
+    [
+        WorkflowTemplateServiceClient,
+        WorkflowTemplateServiceAsyncClient,
+    ],
 )
 def test_workflow_template_service_client_from_service_account_info(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -158,7 +162,11 @@ def test_workflow_template_service_client_service_account_always_use_jwt(
 
 
 @pytest.mark.parametrize(
-    "client_class", [WorkflowTemplateServiceClient, WorkflowTemplateServiceAsyncClient,]
+    "client_class",
+    [
+        WorkflowTemplateServiceClient,
+        WorkflowTemplateServiceAsyncClient,
+    ],
 )
 def test_workflow_template_service_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
@@ -459,7 +467,9 @@ def test_workflow_template_service_client_client_options_scopes(
     client_class, transport_class, transport_name
 ):
     # Check the case scopes are provided.
-    options = client_options.ClientOptions(scopes=["1", "2"],)
+    options = client_options.ClientOptions(
+        scopes=["1", "2"],
+    )
     with mock.patch.object(transport_class, "__init__") as patched:
         patched.return_value = None
         client = client_class(client_options=options)
@@ -535,7 +545,8 @@ def test_create_workflow_template(
     request_type=workflow_templates.CreateWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -548,7 +559,9 @@ def test_create_workflow_template(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = workflow_templates.WorkflowTemplate(
-            id="id_value", name="name_value", version=774,
+            id="id_value",
+            name="name_value",
+            version=774,
         )
         response = client.create_workflow_template(request)
 
@@ -572,7 +585,8 @@ def test_create_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -591,7 +605,8 @@ async def test_create_workflow_template_async(
     request_type=workflow_templates.CreateWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -605,7 +620,9 @@ async def test_create_workflow_template_async(
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             workflow_templates.WorkflowTemplate(
-                id="id_value", name="name_value", version=774,
+                id="id_value",
+                name="name_value",
+                version=774,
             )
         )
         response = await client.create_workflow_template(request)
@@ -652,7 +669,10 @@ def test_create_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -683,7 +703,10 @@ async def test_create_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_create_workflow_template_flattened():
@@ -778,7 +801,8 @@ def test_get_workflow_template(
     transport: str = "grpc", request_type=workflow_templates.GetWorkflowTemplateRequest
 ):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -791,7 +815,9 @@ def test_get_workflow_template(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = workflow_templates.WorkflowTemplate(
-            id="id_value", name="name_value", version=774,
+            id="id_value",
+            name="name_value",
+            version=774,
         )
         response = client.get_workflow_template(request)
 
@@ -815,7 +841,8 @@ def test_get_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -834,7 +861,8 @@ async def test_get_workflow_template_async(
     request_type=workflow_templates.GetWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -848,7 +876,9 @@ async def test_get_workflow_template_async(
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             workflow_templates.WorkflowTemplate(
-                id="id_value", name="name_value", version=774,
+                id="id_value",
+                name="name_value",
+                version=774,
             )
         )
         response = await client.get_workflow_template(request)
@@ -895,7 +925,10 @@ def test_get_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -926,7 +959,10 @@ async def test_get_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_get_workflow_template_flattened():
@@ -942,7 +978,9 @@ def test_get_workflow_template_flattened():
         call.return_value = workflow_templates.WorkflowTemplate()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.get_workflow_template(name="name_value",)
+        client.get_workflow_template(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -960,7 +998,8 @@ def test_get_workflow_template_flattened_error():
     # fields is an error.
     with pytest.raises(ValueError):
         client.get_workflow_template(
-            workflow_templates.GetWorkflowTemplateRequest(), name="name_value",
+            workflow_templates.GetWorkflowTemplateRequest(),
+            name="name_value",
         )
 
 
@@ -982,7 +1021,9 @@ async def test_get_workflow_template_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.get_workflow_template(name="name_value",)
+        response = await client.get_workflow_template(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1001,7 +1042,8 @@ async def test_get_workflow_template_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.get_workflow_template(
-            workflow_templates.GetWorkflowTemplateRequest(), name="name_value",
+            workflow_templates.GetWorkflowTemplateRequest(),
+            name="name_value",
         )
 
 
@@ -1010,7 +1052,8 @@ def test_instantiate_workflow_template(
     request_type=workflow_templates.InstantiateWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1042,7 +1085,8 @@ def test_instantiate_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1061,7 +1105,8 @@ async def test_instantiate_workflow_template_async(
     request_type=workflow_templates.InstantiateWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1117,7 +1162,10 @@ def test_instantiate_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1148,7 +1196,10 @@ async def test_instantiate_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_instantiate_workflow_template_flattened():
@@ -1165,7 +1216,8 @@ def test_instantiate_workflow_template_flattened():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.instantiate_workflow_template(
-            name="name_value", parameters={"key_value": "value_value"},
+            name="name_value",
+            parameters={"key_value": "value_value"},
         )
 
         # Establish that the underlying call was made with the expected
@@ -1210,7 +1262,8 @@ async def test_instantiate_workflow_template_flattened_async():
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.instantiate_workflow_template(
-            name="name_value", parameters={"key_value": "value_value"},
+            name="name_value",
+            parameters={"key_value": "value_value"},
         )
 
         # Establish that the underlying call was made with the expected
@@ -1242,7 +1295,8 @@ def test_instantiate_inline_workflow_template(
     request_type=workflow_templates.InstantiateInlineWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1274,7 +1328,8 @@ def test_instantiate_inline_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1293,7 +1348,8 @@ async def test_instantiate_inline_workflow_template_async(
     request_type=workflow_templates.InstantiateInlineWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1349,7 +1405,10 @@ def test_instantiate_inline_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1380,7 +1439,10 @@ async def test_instantiate_inline_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_instantiate_inline_workflow_template_flattened():
@@ -1476,7 +1538,8 @@ def test_update_workflow_template(
     request_type=workflow_templates.UpdateWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1489,7 +1552,9 @@ def test_update_workflow_template(
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = workflow_templates.WorkflowTemplate(
-            id="id_value", name="name_value", version=774,
+            id="id_value",
+            name="name_value",
+            version=774,
         )
         response = client.update_workflow_template(request)
 
@@ -1513,7 +1578,8 @@ def test_update_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1532,7 +1598,8 @@ async def test_update_workflow_template_async(
     request_type=workflow_templates.UpdateWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1546,7 +1613,9 @@ async def test_update_workflow_template_async(
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             workflow_templates.WorkflowTemplate(
-                id="id_value", name="name_value", version=774,
+                id="id_value",
+                name="name_value",
+                version=774,
             )
         )
         response = await client.update_workflow_template(request)
@@ -1593,9 +1662,10 @@ def test_update_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "template.name=template.name/value",) in kw[
-        "metadata"
-    ]
+    assert (
+        "x-goog-request-params",
+        "template.name=template.name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1626,9 +1696,10 @@ async def test_update_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "template.name=template.name/value",) in kw[
-        "metadata"
-    ]
+    assert (
+        "x-goog-request-params",
+        "template.name=template.name/value",
+    ) in kw["metadata"]
 
 
 def test_update_workflow_template_flattened():
@@ -1718,7 +1789,8 @@ def test_list_workflow_templates(
     request_type=workflow_templates.ListWorkflowTemplatesRequest,
 ):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1753,7 +1825,8 @@ def test_list_workflow_templates_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -1772,7 +1845,8 @@ async def test_list_workflow_templates_async(
     request_type=workflow_templates.ListWorkflowTemplatesRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1831,7 +1905,10 @@ def test_list_workflow_templates_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1862,7 +1939,10 @@ async def test_list_workflow_templates_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_list_workflow_templates_flattened():
@@ -1878,7 +1958,9 @@ def test_list_workflow_templates_flattened():
         call.return_value = workflow_templates.ListWorkflowTemplatesResponse()
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.list_workflow_templates(parent="parent_value",)
+        client.list_workflow_templates(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1896,7 +1978,8 @@ def test_list_workflow_templates_flattened_error():
     # fields is an error.
     with pytest.raises(ValueError):
         client.list_workflow_templates(
-            workflow_templates.ListWorkflowTemplatesRequest(), parent="parent_value",
+            workflow_templates.ListWorkflowTemplatesRequest(),
+            parent="parent_value",
         )
 
 
@@ -1918,7 +2001,9 @@ async def test_list_workflow_templates_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.list_workflow_templates(parent="parent_value",)
+        response = await client.list_workflow_templates(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1937,7 +2022,8 @@ async def test_list_workflow_templates_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.list_workflow_templates(
-            workflow_templates.ListWorkflowTemplatesRequest(), parent="parent_value",
+            workflow_templates.ListWorkflowTemplatesRequest(),
+            parent="parent_value",
         )
 
 
@@ -1961,10 +2047,13 @@ def test_list_workflow_templates_pager():
                 next_page_token="abc",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[], next_page_token="def",
+                templates=[],
+                next_page_token="def",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[workflow_templates.WorkflowTemplate(),],
+                templates=[
+                    workflow_templates.WorkflowTemplate(),
+                ],
                 next_page_token="ghi",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
@@ -2009,10 +2098,13 @@ def test_list_workflow_templates_pages():
                 next_page_token="abc",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[], next_page_token="def",
+                templates=[],
+                next_page_token="def",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[workflow_templates.WorkflowTemplate(),],
+                templates=[
+                    workflow_templates.WorkflowTemplate(),
+                ],
                 next_page_token="ghi",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
@@ -2051,10 +2143,13 @@ async def test_list_workflow_templates_async_pager():
                 next_page_token="abc",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[], next_page_token="def",
+                templates=[],
+                next_page_token="def",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[workflow_templates.WorkflowTemplate(),],
+                templates=[
+                    workflow_templates.WorkflowTemplate(),
+                ],
                 next_page_token="ghi",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
@@ -2065,7 +2160,9 @@ async def test_list_workflow_templates_async_pager():
             ),
             RuntimeError,
         )
-        async_pager = await client.list_workflow_templates(request={},)
+        async_pager = await client.list_workflow_templates(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -2100,10 +2197,13 @@ async def test_list_workflow_templates_async_pages():
                 next_page_token="abc",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[], next_page_token="def",
+                templates=[],
+                next_page_token="def",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
-                templates=[workflow_templates.WorkflowTemplate(),],
+                templates=[
+                    workflow_templates.WorkflowTemplate(),
+                ],
                 next_page_token="ghi",
             ),
             workflow_templates.ListWorkflowTemplatesResponse(
@@ -2126,7 +2226,8 @@ def test_delete_workflow_template(
     request_type=workflow_templates.DeleteWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2158,7 +2259,8 @@ def test_delete_workflow_template_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -2177,7 +2279,8 @@ async def test_delete_workflow_template_async(
     request_type=workflow_templates.DeleteWorkflowTemplateRequest,
 ):
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2231,7 +2334,10 @@ def test_delete_workflow_template_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -2260,7 +2366,10 @@ async def test_delete_workflow_template_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_delete_workflow_template_flattened():
@@ -2276,7 +2385,9 @@ def test_delete_workflow_template_flattened():
         call.return_value = None
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.delete_workflow_template(name="name_value",)
+        client.delete_workflow_template(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2294,7 +2405,8 @@ def test_delete_workflow_template_flattened_error():
     # fields is an error.
     with pytest.raises(ValueError):
         client.delete_workflow_template(
-            workflow_templates.DeleteWorkflowTemplateRequest(), name="name_value",
+            workflow_templates.DeleteWorkflowTemplateRequest(),
+            name="name_value",
         )
 
 
@@ -2314,7 +2426,9 @@ async def test_delete_workflow_template_flattened_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.delete_workflow_template(name="name_value",)
+        response = await client.delete_workflow_template(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2333,7 +2447,8 @@ async def test_delete_workflow_template_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.delete_workflow_template(
-            workflow_templates.DeleteWorkflowTemplateRequest(), name="name_value",
+            workflow_templates.DeleteWorkflowTemplateRequest(),
+            name="name_value",
         )
 
 
@@ -2344,7 +2459,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = WorkflowTemplateServiceClient(
-            credentials=ga_credentials.AnonymousCredentials(), transport=transport,
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
@@ -2363,7 +2479,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = WorkflowTemplateServiceClient(
-            client_options={"scopes": ["1", "2"]}, transport=transport,
+            client_options={"scopes": ["1", "2"]},
+            transport=transport,
         )
 
 
@@ -2412,7 +2529,8 @@ def test_transport_grpc_default():
         credentials=ga_credentials.AnonymousCredentials(),
     )
     assert isinstance(
-        client.transport, transports.WorkflowTemplateServiceGrpcTransport,
+        client.transport,
+        transports.WorkflowTemplateServiceGrpcTransport,
     )
 
 
@@ -2467,7 +2585,8 @@ def test_workflow_template_service_base_transport_with_credentials_file():
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.WorkflowTemplateServiceTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -2488,7 +2607,8 @@ def test_workflow_template_service_base_transport_with_credentials_file_old_goog
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         transport = transports.WorkflowTemplateServiceTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -2683,7 +2803,8 @@ def test_workflow_template_service_grpc_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.WorkflowTemplateServiceGrpcTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2695,7 +2816,8 @@ def test_workflow_template_service_grpc_asyncio_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.WorkflowTemplateServiceGrpcAsyncIOTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -2804,12 +2926,16 @@ def test_workflow_template_service_transport_channel_mtls_with_adc(transport_cla
 
 def test_workflow_template_service_grpc_lro_client():
     client = WorkflowTemplateServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2817,12 +2943,16 @@ def test_workflow_template_service_grpc_lro_client():
 
 def test_workflow_template_service_grpc_lro_async_client():
     client = WorkflowTemplateServiceAsyncClient(
-        credentials=ga_credentials.AnonymousCredentials(), transport="grpc_asyncio",
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
     )
     transport = client.transport
 
     # Ensure that we have a api-core operations client.
-    assert isinstance(transport.operations_client, operations_v1.OperationsAsyncClient,)
+    assert isinstance(
+        transport.operations_client,
+        operations_v1.OperationsAsyncClient,
+    )
 
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
@@ -2833,7 +2963,9 @@ def test_cluster_path():
     location = "clam"
     cluster = "whelk"
     expected = "projects/{project}/locations/{location}/clusters/{cluster}".format(
-        project=project, location=location, cluster=cluster,
+        project=project,
+        location=location,
+        cluster=cluster,
     )
     actual = WorkflowTemplateServiceClient.cluster_path(project, location, cluster)
     assert expected == actual
@@ -2857,7 +2989,9 @@ def test_service_path():
     location = "mussel"
     service = "winkle"
     expected = "projects/{project}/locations/{location}/services/{service}".format(
-        project=project, location=location, service=service,
+        project=project,
+        location=location,
+        service=service,
     )
     actual = WorkflowTemplateServiceClient.service_path(project, location, service)
     assert expected == actual
@@ -2881,7 +3015,9 @@ def test_workflow_template_path():
     region = "clam"
     workflow_template = "whelk"
     expected = "projects/{project}/regions/{region}/workflowTemplates/{workflow_template}".format(
-        project=project, region=region, workflow_template=workflow_template,
+        project=project,
+        region=region,
+        workflow_template=workflow_template,
     )
     actual = WorkflowTemplateServiceClient.workflow_template_path(
         project, region, workflow_template
@@ -2924,7 +3060,9 @@ def test_parse_common_billing_account_path():
 
 def test_common_folder_path():
     folder = "winkle"
-    expected = "folders/{folder}".format(folder=folder,)
+    expected = "folders/{folder}".format(
+        folder=folder,
+    )
     actual = WorkflowTemplateServiceClient.common_folder_path(folder)
     assert expected == actual
 
@@ -2942,7 +3080,9 @@ def test_parse_common_folder_path():
 
 def test_common_organization_path():
     organization = "scallop"
-    expected = "organizations/{organization}".format(organization=organization,)
+    expected = "organizations/{organization}".format(
+        organization=organization,
+    )
     actual = WorkflowTemplateServiceClient.common_organization_path(organization)
     assert expected == actual
 
@@ -2960,7 +3100,9 @@ def test_parse_common_organization_path():
 
 def test_common_project_path():
     project = "squid"
-    expected = "projects/{project}".format(project=project,)
+    expected = "projects/{project}".format(
+        project=project,
+    )
     actual = WorkflowTemplateServiceClient.common_project_path(project)
     assert expected == actual
 
@@ -2980,7 +3122,8 @@ def test_common_location_path():
     project = "whelk"
     location = "octopus"
     expected = "projects/{project}/locations/{location}".format(
-        project=project, location=location,
+        project=project,
+        location=location,
     )
     actual = WorkflowTemplateServiceClient.common_location_path(project, location)
     assert expected == actual
@@ -3005,7 +3148,8 @@ def test_client_withDEFAULT_CLIENT_INFO():
         transports.WorkflowTemplateServiceTransport, "_prep_wrapped_messages"
     ) as prep:
         client = WorkflowTemplateServiceClient(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -3014,6 +3158,7 @@ def test_client_withDEFAULT_CLIENT_INFO():
     ) as prep:
         transport_class = WorkflowTemplateServiceClient.get_transport_class()
         transport = transport_class(
-            credentials=ga_credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v2**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566