### PR TITLE
docs(samples): resolve issue where submit_job_to_cluster sample fails to submit job

### DIFF
--- a/samples/snippets/noxfile.py
+++ b/samples/snippets/noxfile.py
@@ -208,9 +208,7 @@ def _session_tests(
 
     if os.path.exists("requirements-test.txt"):
         if os.path.exists("constraints-test.txt"):
-            session.install(
-                "-r", "requirements-test.txt", "-c", "constraints-test.txt"
-            )
+            session.install("-r", "requirements-test.txt", "-c", "constraints-test.txt")
         else:
             session.install("-r", "requirements-test.txt")
         with open("requirements-test.txt") as rtfile:
@@ -223,9 +221,9 @@ def _session_tests(
         post_install(session)
 
     if "pytest-parallel" in packages:
-        concurrent_args.extend(['--workers', 'auto', '--tests-per-worker', 'auto'])
+        concurrent_args.extend(["--workers", "auto", "--tests-per-worker", "auto"])
     elif "pytest-xdist" in packages:
-        concurrent_args.extend(['-n', 'auto'])
+        concurrent_args.extend(["-n", "auto"])
 
     session.run(
         "pytest",
@@ -255,7 +253,7 @@ def py(session: nox.sessions.Session) -> None:
 
 
 def _get_repo_root() -> Optional[str]:
-    """ Returns the root folder of the project. """
+    """Returns the root folder of the project."""
     # Get root of this repository. Assume we don't have directories nested deeper than 10 items.
     p = Path(os.getcwd())
     for i in range(10):

--- a/samples/snippets/submit_job_to_cluster.py
+++ b/samples/snippets/submit_job_to_cluster.py
@@ -75,8 +75,10 @@ def download_output(project, cluster_id, output_bucket, job_id):
     print("Downloading output file.")
     client = storage.Client(project=project)
     bucket = client.get_bucket(output_bucket)
-    output_blob = "google-cloud-dataproc-metainfo/{}/jobs/{}/driveroutput.000000000".format(
-        cluster_id, job_id
+    output_blob = (
+        "google-cloud-dataproc-metainfo/{}/jobs/{}/driveroutput.000000000".format(
+            cluster_id, job_id
+        )
     )
     return bucket.blob(output_blob).download_as_string()
 
@@ -131,7 +133,14 @@ def list_clusters_with_details(dataproc, project, region):
     for cluster in dataproc.list_clusters(
         request={"project_id": project, "region": region}
     ):
-        print(("{} - {}".format(cluster.cluster_name, cluster.status.state.name,)))
+        print(
+            (
+                "{} - {}".format(
+                    cluster.cluster_name,
+                    cluster.status.state.name,
+                )
+            )
+        )
 
 
 # [END dataproc_list_clusters_with_detail]
@@ -224,7 +233,7 @@ def main(
         dataproc_cluster_client = dataproc_v1.ClusterControllerClient(
             client_options={"api_endpoint": f"{region}-dataproc.googleapis.com:443"}
         )
-        dataproc_job_client = dataproc_v1.ClusterControllerClient(
+        dataproc_job_client = dataproc_v1.JobControllerClient(
             client_options={"api_endpoint": f"{region}-dataproc.googleapis.com:443"}
         )
     # [END dataproc_get_client]


### PR DESCRIPTION
submit_job_to_cluster.py sample had a bug preventing it from working at all. This commit also includes minor lint fixes generated by `nox`.

This sample does not have unit tests itself, but all other unit tests still pass after this change. Manual invocation of `submit_job_to_cluster.py` according to the docs now works:

```
$ python3 submit_job_to_cluster.py --project_id=$GOOGLE_CLOUD_PROJECT --zone=us-central1-b --cluster_name=$CLUSTER --gcs_bucket=$BUCKET
E0330 02:53:04.399655884 2746560 fork_posix.cc:70]           Fork support is only compatible with the epoll1 and poll polling strategies
Uploading pyspark file to Cloud Storage.
cee-test-cluster - RUNNING                                                                                                                             
Submitted job ID 713a7eb5-67a8-4257-b9b6-fbf7481695a9.
Waiting for job to finish...
Job finished.
Downloading output file.
Received job output b"22/03/30 02:53:13 INFO org.apache.spark.SparkEnv: Registering MapOutputTracker\n22/03/30 02:53:13 INFO org.apache.spark.SparkEnv:
<SNIP>
verified object already exists with desired state.\n['Hello,', 'dog', 'elephant', 'panther', 'world!']\n22/03/30 02:53:30 INFO org.sparkproject.jetty.server.AbstractConnector: Stopped Spark@167a9a25{HTTP/1.1, (http/1.1)}{0.0.0.0:0}\n"
```

Fixes #384 
